### PR TITLE
Add ACMREQ message loader with search capability

### DIFF
--- a/services/tak-ingest-svc/data/Canada/sample.json
+++ b/services/tak-ingest-svc/data/Canada/sample.json
@@ -1,0 +1,1 @@
+{"ACMREQ": {"message": "Canada sample message"}}

--- a/services/tak-ingest-svc/data/NATO/sample.json
+++ b/services/tak-ingest-svc/data/NATO/sample.json
@@ -1,0 +1,1 @@
+{"ACMREQ": {"message": "NATO sample message"}}

--- a/services/tak-ingest-svc/index.js
+++ b/services/tak-ingest-svc/index.js
@@ -1,5 +1,28 @@
 const express = require('express');
+const loadMessages = require('./messageLoader');
+
 const app = express();
+let cache = [];
+
+async function ensureCache() {
+  if (cache.length === 0) {
+    cache = await loadMessages();
+  }
+}
+
 app.get('/health', (_req, res) => res.send('tak ingest ok'));
+
+app.get('/messages', async (req, res) => {
+  await ensureCache();
+  const q = (req.query.q || '').toLowerCase();
+  const result = !q
+    ? cache
+    : cache.filter((m) => {
+        const target = m.message ? m.message : JSON.stringify(m);
+        return target.toLowerCase().includes(q);
+      });
+  res.json(result);
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`tak-ingest-svc listening on ${PORT}`));

--- a/services/tak-ingest-svc/messageLoader.js
+++ b/services/tak-ingest-svc/messageLoader.js
@@ -1,0 +1,58 @@
+const fs = require('fs').promises;
+const path = require('path');
+let S3Client, ListObjectsV2Command, GetObjectCommand;
+
+async function streamToString(stream) {
+  return await new Promise((resolve, reject) => {
+    const chunks = [];
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('error', reject);
+    stream.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+  });
+}
+
+async function loadFromS3(bucket, prefixes) {
+  if (!S3Client) {
+    ({ S3Client, ListObjectsV2Command, GetObjectCommand } = require('@aws-sdk/client-s3'));
+  }
+  const client = new S3Client();
+  const messages = [];
+  for (const prefix of prefixes) {
+    const list = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix })
+    );
+    for (const obj of list.Contents || []) {
+      const { Body } = await client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: obj.Key })
+      );
+      const json = JSON.parse(await streamToString(Body));
+      const message = json.message || (json.ACMREQ && json.ACMREQ.message) || '';
+      messages.push({ ...json, folder: prefix.replace(/\/$/, ''), message });
+    }
+  }
+  return messages;
+}
+
+async function loadFromLocal(basePath, folders) {
+  const messages = [];
+  for (const folder of folders) {
+    const dir = path.join(basePath, folder);
+    const files = await fs.readdir(dir);
+    for (const file of files.filter((f) => f.endsWith('.json'))) {
+      const json = JSON.parse(await fs.readFile(path.join(dir, file), 'utf-8'));
+      const message = json.message || (json.ACMREQ && json.ACMREQ.message) || '';
+      messages.push({ ...json, folder, message });
+    }
+  }
+  return messages;
+}
+
+module.exports = async function loadMessages() {
+  const bucket = process.env.S3_BUCKET;
+  const folders = ['NATO', 'Canada'];
+  if (bucket) {
+    return loadFromS3(bucket, folders.map((f) => `${f}/`));
+  }
+  const basePath = process.env.LOCAL_MESSAGE_DIR || path.join(__dirname, 'data');
+  return loadFromLocal(basePath, folders);
+};

--- a/services/tak-ingest-svc/package.json
+++ b/services/tak-ingest-svc/package.json
@@ -7,6 +7,7 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "@aws-sdk/client-s3": "^3.514.0"
   }
 }


### PR DESCRIPTION
## Summary
- load ACMREQ JSON messages from S3 bucket or local NATO/Canada folders
- expose `/messages` API to search messages by text
- include AWS S3 client dependency and sample data

## Testing
- `npm test`
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@aws-sdk%2fclient-s3)*

------
https://chatgpt.com/codex/tasks/task_e_689ff60f6cec83238a8658a2112ff7f2