### PR TITLE
feat: add LDAP mock auth service with token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ TACTIX (Tactical Assistance and Collaboration Tool for Incident eXchange) is a m
 This repository contains a containerized skeleton for the core services:
 
 - **gateway** – NGINX reverse proxy
-- **auth-svc** – LDAP authentication and JWT issuance
+- **auth-svc** – LDAP mock authentication service providing `/auth/login` and `/auth/refresh`
 - **incident-svc** – event‑sourced incident tracking
 - **tak-ingest-svc** – Cursor-on-Target ingest pipeline
 - **realtime-svc** – WebSocket gateway

--- a/services/auth-svc/package.json
+++ b/services/auth-svc/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.0",
-    "ldapjs": "^2.3.3"
+    "jsonwebtoken": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add in-memory LDAP mock
- issue JWT and refresh tokens via /auth/login
- allow token renewal via /auth/refresh

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fff0398108323abe9ccb8e7c5142b