### PR TITLE
feat: enforce auth at gateway

### DIFF
--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -2,19 +2,34 @@ events {}
 http {
   server {
     listen 80;
+    proxy_set_header Authorization $http_authorization;
+
     location / {
       proxy_pass http://ui:3000/;
     }
+
     location /auth/ {
       proxy_pass http://auth-svc:3000/;
     }
+
     location /api/ {
+      if ($http_authorization = "") {
+        return 401;
+      }
       proxy_pass http://incident-svc:3000/;
     }
+
     location /rt/ {
+      if ($http_authorization = "") {
+        return 401;
+      }
       proxy_pass http://realtime-svc:3000/;
     }
+
     location /warlog/ {
+      if ($http_authorization = "") {
+        return 401;
+      }
       proxy_pass http://warlog-svc:3000/;
     }
   }


### PR DESCRIPTION
## Summary
- forward Authorization header through gateway
- reject protected requests without a JWT

## Testing
- `npm test` (services/auth-svc)
- `npm test` (services/incident-svc)
- `nginx -t -c ops/nginx.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fff0943e08323a2e4450cf460ef2c