### PR TITLE
Add Redis Streams producer/consumer demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,27 @@ npm test
 ```
 
 These are placeholders until real tests are added.
+
+## Redis Streams Demo
+
+The realtime service includes simple producer/consumer scripts demonstrating
+Redis Streams usage. Example keys:
+
+- `rt.incident.{id}` – incident-specific stream
+- `rt.system.broadcast` – system-wide broadcast stream
+
+Run the producer to append a message:
+
+```bash
+node services/realtime-svc/stream-producer.js rt.system.broadcast "hello"
+```
+
+Start the consumer to read and persist the last ID, allowing replay after
+restart:
+
+```bash
+node services/realtime-svc/stream-consumer.js rt.system.broadcast
+```
+
+The consumer stores the last seen ID in a local file and resumes from that
+point on subsequent runs.

--- a/services/realtime-svc/package.json
+++ b/services/realtime-svc/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@xmpp/client": "^0.13.1",
     "express": "^4.18.2",
-    "ws": "^8.13.0"
+    "ws": "^8.13.0",
+    "redis": "^4.6.7"
   }
 }

--- a/services/realtime-svc/stream-consumer.js
+++ b/services/realtime-svc/stream-consumer.js
@@ -1,0 +1,37 @@
+const { createClient } = require('redis');
+const fs = require('fs');
+const path = require('path');
+
+const stream = process.argv[2];
+if (!stream) {
+  console.error('usage: node stream-consumer.js <stream>');
+  process.exit(1);
+}
+
+const lastIdFile = path.join(__dirname, `${stream.replace(/[.:]/g, '_')}.lastid`);
+
+(async () => {
+  const client = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
+  client.on('error', err => console.error('redis error', err));
+  await client.connect();
+
+  let lastId = '0-0';
+  if (fs.existsSync(lastIdFile)) {
+    lastId = fs.readFileSync(lastIdFile, 'utf8');
+  }
+
+  while (true) {
+    const data = await client.xRead(
+      [{ key: stream, id: lastId }],
+      { BLOCK: 5000 }
+    );
+    if (data) {
+      const messages = data[0].messages;
+      for (const m of messages) {
+        console.log(`[${m.id}]`, m.message.message);
+        lastId = m.id;
+      }
+      fs.writeFileSync(lastIdFile, lastId);
+    }
+  }
+})();

--- a/services/realtime-svc/stream-producer.js
+++ b/services/realtime-svc/stream-producer.js
@@ -1,0 +1,18 @@
+const { createClient } = require('redis');
+
+const stream = process.argv[2];
+if (!stream) {
+  console.error('usage: node stream-producer.js <stream> [message]');
+  process.exit(1);
+}
+
+const message = process.argv[3] || `msg ${Date.now()}`;
+
+(async () => {
+  const client = createClient({ url: process.env.REDIS_URL || 'redis://localhost:6379' });
+  client.on('error', err => console.error('redis error', err));
+  await client.connect();
+  const id = await client.xAdd(stream, '*', { message });
+  console.log(`added ${id} to ${stream}`);
+  await client.quit();
+})();


### PR DESCRIPTION
## Summary
- add demo scripts for Redis Streams producer and consumer
- document stream keys and demo usage
- include redis client dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fff2e37608323baa320ecdeb66799