### PR TITLE
docs: add issue titles list

### DIFF
--- a/ISSUE_TITLES.md
+++ b/ISSUE_TITLES.md
@@ -1,0 +1,17 @@
+# Issue Titles
+
+- [A1] Health endpoints & compose parity
+- [B1] Auth service: LDAP mock + JWT/refresh
+- [B2] Gateway JWT enforcement
+- [C1] Incident DB migrations
+- [C2] Incident Service REST (event-sourced)
+- [D1] Redis Streams setup
+- [D2] WebSocket gateway with backpressure
+- [D3] Incident event fan-out
+- [E1] TAK CoT ingest + filters
+- [E2] GeoJSON export
+- [F1] UI login + token refresh
+- [F2] UI dashboard (Warlog/Chat)
+- [G1] MinIO attachments
+- [G2] OpenSearch indexer (in development)
+


### PR DESCRIPTION
## Summary
- add ISSUE_TITLES.md with roadmap issue titles for copy-paste
- note OpenSearch indexer issue is in development

## Testing
- `for dir in ui services/auth-svc services/incident-svc services/realtime-svc services/tak-ingest-svc services/warlog-svc; do (cd $dir && npm test); done`


------
https://chatgpt.com/codex/tasks/task_e_689fff975ba4832383d911e15152a267