### PR TITLE
feat: add OpenSearch-backed warlog search

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - ./ops/env/warlog.env
     depends_on:
       - postgres
+      - opensearch
   tak-ingest-svc:
     build: ./services/tak-ingest-svc
     env_file:

--- a/ops/env/warlog.env
+++ b/ops/env/warlog.env
@@ -1,2 +1,3 @@
 PORT=3000
 DATABASE_URL=postgres://tactix:tactix@postgres:5432/tactix
+OPENSEARCH_URL=http://opensearch:9200

--- a/services/warlog-svc/index.js
+++ b/services/warlog-svc/index.js
@@ -1,12 +1,14 @@
 const express = require('express');
 const { Pool } = require('pg');
+const { Client } = require('@opensearch-project/opensearch');
 
 const app = express();
 app.use(express.json());
 
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+let osClient = null;
 
-// Ensure table exists
+// Ensure table and OpenSearch index exist
 async function init() {
   await pool.query(`CREATE TABLE IF NOT EXISTS warlog (
     id SERIAL PRIMARY KEY,
@@ -14,17 +16,52 @@ async function init() {
     content TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
   );`);
+
+  try {
+    osClient = new Client({ node: process.env.OPENSEARCH_URL || 'http://opensearch:9200' });
+    await osClient.ping();
+    await osClient.indices.create({ index: 'warlog' }, { ignore: [400] });
+    console.log('Connected to OpenSearch');
+  } catch (err) {
+    osClient = null;
+    console.warn('OpenSearch unavailable, falling back to Postgres search');
+  }
 }
+
 init().catch(err => {
-  console.error('Failed to initialize database', err);
+  console.error('Failed to initialize', err);
   process.exit(1);
 });
 
 app.get('/health', (_req, res) => res.send('warlog ok'));
 
-app.get('/entries', async (_req, res) => {
+app.get('/entries', async (req, res) => {
+  const { q } = req.query;
   try {
-    const { rows } = await pool.query('SELECT id, author, content, created_at FROM warlog ORDER BY created_at ASC');
+    if (q && osClient) {
+      const result = await osClient.search({
+        index: 'warlog',
+        body: { query: { match: { content: q } } }
+      });
+      const hits = result.hits.hits.map(h => ({
+        id: Number(h._id),
+        author: h._source.author,
+        content: h._source.content,
+        created_at: h._source.created_at
+      }));
+      return res.json(hits);
+    }
+
+    const query = q
+      ? {
+          text: 'SELECT id, author, content, created_at FROM warlog WHERE content ILIKE $1 ORDER BY created_at ASC',
+          params: [`%${q}%`]
+        }
+      : {
+          text: 'SELECT id, author, content, created_at FROM warlog ORDER BY created_at ASC',
+          params: []
+        };
+    const { rows } = await pool.query(query.text, query.params);
     res.json(rows);
   } catch (err) {
     console.error(err);
@@ -42,7 +79,17 @@ app.post('/entries', async (req, res) => {
       'INSERT INTO warlog (author, content) VALUES ($1, $2) RETURNING id, author, content, created_at',
       [author, content]
     );
-    res.status(201).json(rows[0]);
+    const entry = rows[0];
+
+    if (osClient) {
+      await osClient.index({
+        index: 'warlog',
+        id: String(entry.id),
+        body: entry
+      });
+    }
+
+    res.status(201).json(entry);
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'failed to create warlog entry' });

--- a/services/warlog-svc/package.json
+++ b/services/warlog-svc/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "@opensearch-project/opensearch": "^2.11.0"
   }
 }


### PR DESCRIPTION
## Summary
- index warlog entries in OpenSearch when available
- search warlog entries through OpenSearch with `q` parameter
- wire warlog service to OpenSearch container and env configuration

## Testing
- `cd services/warlog-svc && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fff67c1b08323a1dca62ca1b1a1d4