### PR TITLE
feat: add basic incident search

### DIFF
--- a/ops/postgres/init.sql
+++ b/ops/postgres/init.sql
@@ -1,8 +1,18 @@
--- Database initialization for campaigns, operations, units, and warlog entries
+-- Database initialization for campaigns, operations, units, incidents, and warlog entries
 CREATE TABLE IF NOT EXISTS campaigns (
   id SERIAL PRIMARY KEY,
   name TEXT NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS incidents (
+  id SERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT
+);
+
+-- Seed initial incident for development/testing
+INSERT INTO incidents (title, description)
+VALUES ('Fire in Building', 'Report of a fire at the warehouse');
 
 CREATE TABLE IF NOT EXISTS operations (
   id SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- store incidents in Postgres with initial seed data
- expose /incidents endpoint with optional `q` filter searching title and description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fff2851348323b43931e63fef0ba6