### PR TITLE
feat: fan out comments via postgres

### DIFF
--- a/services/realtime-svc/package.json
+++ b/services/realtime-svc/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@xmpp/client": "^0.13.1",
     "express": "^4.18.2",
+    "pg": "^8.11.3",
     "ws": "^8.13.0"
   }
 }


### PR DESCRIPTION
## Summary
- publish comment events from incident-svc after database commit
- subscribe to Postgres notifications in realtime-svc and broadcast to WebSocket clients
- add pg dependency for realtime-svc

## Testing
- `npm test` (incident-svc)
- `npm test` (realtime-svc)


------
https://chatgpt.com/codex/tasks/task_e_689fff37d3fc8323917af01e627b5573