### PR TITLE
feat: add attachment upload endpoint with event emission

### DIFF
--- a/ops/env/incident.env
+++ b/ops/env/incident.env
@@ -1,2 +1,7 @@
 PORT=3000
 DATABASE_URL=postgres://tactix:tactix@postgres:5432/tactix
+MINIO_ENDPOINT=minio
+MINIO_PORT=9000
+MINIO_ACCESS_KEY=tactix
+MINIO_SECRET_KEY=tactix-secret
+MINIO_BUCKET=tactix


### PR DESCRIPTION
## Summary
- support POST /incidents/:id/attachments for multipart uploads
- store attachment metadata and emit ATTACHMENT_ADDED event
- add MinIO env configuration and tests for upload flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a00889cfac8323add7f32604094944