### PR TITLE
feat: broadcast incident events

### DIFF
--- a/services/realtime-svc/package.json
+++ b/services/realtime-svc/package.json
@@ -7,10 +7,9 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "@xmpp/client": "^0.13.1",
+    "@tactix/lib-db": "workspace:*",
     "express": "^4.18.2",
     "ws": "^8.13.0",
-    "redis": "^4.6.7",
     "dotenv": "^16.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- notify `tactix_events` channel after committing incident events
- websocket realtime service streams Postgres notifications to subscribed clients with bounded queues and snapshot catch-up
- remove xmpp/redis deps and depend on shared `@tactix/lib-db`

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fexpress: Forbidden - 403)*
- `npm test` in `services/incident-svc`
- `npm test` in `services/realtime-svc`


------
https://chatgpt.com/codex/tasks/task_e_68a0553305fc83238c968fcbc9b82779