### PR TITLE
feat(ui): connect UI to incident APIs

### DIFF
--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -4,27 +4,367 @@
 const { useEffect, useState } = React;
 
 function App() {
-  const [feed, setFeed] = useState('Connecting...');
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
+  const [refreshToken, setRefreshToken] = useState(
+    localStorage.getItem('refreshToken') || ''
+  );
+  const [view, setView] = useState(token ? 'list' : 'login');
+  const [detailId, setDetailId] = useState(null);
+
+  function handleLogin(data) {
+    setToken(data.token);
+    setRefreshToken(data.refreshToken);
+    localStorage.setItem('token', data.token);
+    localStorage.setItem('refreshToken', data.refreshToken);
+    setView('list');
+  }
+
+  function logout() {
+    setToken('');
+    setRefreshToken('');
+    localStorage.removeItem('token');
+    localStorage.removeItem('refreshToken');
+    setView('login');
+  }
+
+  // Periodically refresh JWT using refresh token
+  useEffect(() => {
+    if (!refreshToken) return;
+    const id = setInterval(() => {
+      fetch('/auth/refresh', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ refreshToken }),
+      })
+        .then((res) => (res.ok ? res.json() : Promise.reject()))
+        .then((data) => {
+          setToken(data.token);
+          setRefreshToken(data.refreshToken);
+          localStorage.setItem('token', data.token);
+          localStorage.setItem('refreshToken', data.refreshToken);
+        })
+        .catch(() => logout());
+    }, 10 * 60 * 1000); // refresh every 10 minutes
+    return () => clearInterval(id);
+  }, [refreshToken]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">TACTIX</h1>
+      {view === 'login' && <Login onLogin={handleLogin} />}
+      {view === 'list' && (
+        <IncidentList
+          token={token}
+          onSelect={(id) => {
+            setDetailId(id);
+            setView('detail');
+          }}
+          onLogout={logout}
+        />
+      )}
+      {view === 'detail' && (
+        <IncidentDetail
+          token={token}
+          incidentId={detailId}
+          onBack={() => setView('list')}
+        />
+      )}
+    </div>
+  );
+}
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = (e) => {
+    e.preventDefault();
+    fetch('/auth/login', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then(onLogin)
+      .catch(() => setError('Login failed'));
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-2 max-w-sm">
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+      <input
+        className="border rounded p-1 w-full"
+        placeholder="username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        className="border rounded p-1 w-full"
+        type="password"
+        placeholder="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button
+        className="bg-blue-600 text-white px-3 py-1 rounded"
+        type="submit"
+      >
+        Login
+      </button>
+    </form>
+  );
+}
+
+function IncidentList({ token, onSelect, onLogout }) {
+  const [incidents, setIncidents] = useState([]);
+  const [title, setTitle] = useState('');
+  const [severity, setSeverity] = useState('');
+  const [description, setDescription] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [q, setQ] = useState('');
+
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  useEffect(() => {
+    let url = '/incidents';
+    if (q) url += `?q=${encodeURIComponent(q)}`;
+    fetch(url, { headers })
+      .then((res) => res.json())
+      .then(setIncidents)
+      .catch(() => setIncidents([]));
+  }, [q, token]);
+
+  const createIncident = (e) => {
+    e.preventDefault();
+    fetch('/incidents', {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ title, severity, description }),
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((incident) => {
+        setTitle('');
+        setSeverity('');
+        setDescription('');
+        onSelect(incident.id);
+      })
+      .catch(() => {});
+  };
+
+  const search = (e) => {
+    e.preventDefault();
+    setQ(searchInput);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold">Incidents</h2>
+        <button
+          className="text-sm text-blue-600 underline"
+          onClick={onLogout}
+        >
+          Logout
+        </button>
+      </div>
+      <form onSubmit={search} className="flex gap-2">
+        <input
+          className="border rounded p-1 flex-1"
+          placeholder="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+        />
+        <button className="bg-gray-200 px-2 rounded" type="submit">
+          Search
+        </button>
+      </form>
+      <ul className="space-y-1">
+        {incidents.map((i) => (
+          <li key={i.id}>
+            <button
+              className="text-blue-600 underline"
+              onClick={() => onSelect(i.id)}
+            >
+              {i.title} – {i.status}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <h3 className="font-semibold">Create Incident</h3>
+        <form onSubmit={createIncident} className="space-y-2 max-w-md">
+          <input
+            className="border rounded p-1 w-full"
+            placeholder="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+          />
+          <input
+            className="border rounded p-1 w-full"
+            placeholder="severity"
+            value={severity}
+            onChange={(e) => setSeverity(e.target.value)}
+            required
+          />
+          <textarea
+            className="border rounded p-1 w-full"
+            placeholder="description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <button
+            className="bg-blue-600 text-white px-3 py-1 rounded"
+            type="submit"
+          >
+            Create
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function IncidentDetail({ token, incidentId, onBack }) {
+  const [incident, setIncident] = useState(null);
+  const [comment, setComment] = useState('');
+  const [warlog, setWarlog] = useState([]);
+
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+  useEffect(() => {
+    fetch(`/incidents/${incidentId}`, { headers })
+      .then((res) => res.json())
+      .then((data) => {
+        setIncident(data);
+        const log = [
+          {
+            time: new Date(data.createdAt).toISOString(),
+            title: 'CREATED',
+            text: data.title,
+          },
+          ...data.comments.map((c) => ({
+            time: '',
+            title: 'COMMENT',
+            text: c,
+          })),
+        ];
+        setWarlog(log);
+      });
+  }, [incidentId]);
 
   useEffect(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const ws = new WebSocket(`${protocol}://${window.location.host}/rt`);
-    ws.onopen = () => setFeed('Connected');
-    ws.onmessage = (evt) => setFeed((prev) => `${prev}\n${evt.data}`.trim());
-    ws.onerror = () => setFeed('WebSocket error');
-    ws.onclose = () => setFeed((prev) => `${prev}\nDisconnected`);
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'subscribe', incidentId }));
+    };
+    ws.onmessage = (evt) => {
+      let msg;
+      try {
+        msg = JSON.parse(evt.data);
+      } catch {
+        return;
+      }
+      if (msg.type === 'snapshot') {
+        setIncident(msg.incident);
+        const log = [
+          {
+            time: new Date(msg.incident.createdAt).toISOString(),
+            title: 'CREATED',
+            text: msg.incident.title,
+          },
+          ...msg.incident.comments.map((c) => ({
+            time: '',
+            title: 'COMMENT',
+            text: c,
+          })),
+        ];
+        setWarlog(log);
+      } else if (msg.type === 'COMMENT_ADDED') {
+        setIncident((prev) => ({
+          ...prev,
+          comments: [...(prev?.comments || []), msg.payload.comment],
+        }));
+        setWarlog((prev) => [
+          ...prev,
+          {
+            time: new Date().toISOString(),
+            title: 'COMMENT',
+            text: msg.payload.comment,
+          },
+        ]);
+      } else if (msg.type === 'STATUS_CHANGED') {
+        setWarlog((prev) => [
+          ...prev,
+          {
+            time: new Date().toISOString(),
+            title: 'STATUS',
+            text: msg.payload.status,
+          },
+        ]);
+      } else if (msg.type === 'CREATED') {
+        setWarlog((prev) => [
+          ...prev,
+          {
+            time: new Date().toISOString(),
+            title: 'CREATED',
+            text: msg.payload.title,
+          },
+        ]);
+      }
+    };
     return () => ws.close();
-  }, []);
+  }, [incidentId]);
+
+  const submit = (e) => {
+    e.preventDefault();
+    fetch(`/incidents/${incidentId}/comment`, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ comment }),
+    }).then(() => setComment(''));
+  };
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">TACTIX</h1>
-      <pre
-        id="feed"
-        className="bg-black text-green-200 p-2 rounded text-xs whitespace-pre-wrap"
-      >
-        {feed}
-      </pre>
+    <div className="space-y-4">
+      <button className="text-blue-600 underline" onClick={onBack}>
+        &larr; Back
+      </button>
+      {incident && (
+        <div>
+          <h2 className="text-lg font-semibold">{incident.title}</h2>
+          <p>Severity: {incident.severity}</p>
+          <p>Status: {incident.status}</p>
+        </div>
+      )}
+      <div>
+        <h3 className="font-semibold">Warlog</h3>
+        <div className="bg-black text-green-200 p-2 rounded text-xs h-64 overflow-y-auto">
+          {warlog.map((e, idx) => (
+            <div
+              key={idx}
+              className="grid grid-cols-[auto_auto_1fr] gap-2 mb-1 whitespace-pre-wrap"
+            >
+              <div className="text-gray-400">{e.time}</div>
+              <div className="font-bold">{e.title}</div>
+              <div>{e.text}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <form onSubmit={submit} className="flex gap-2">
+        <input
+          className="border rounded p-1 flex-1"
+          placeholder="Add comment"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+        />
+        <button className="bg-blue-600 text-white px-3 rounded" type="submit">
+          Send
+        </button>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add JWT login with periodic refresh
- list and search incidents; allow creation
- incident detail view with live warlog and comment posting

## Testing
- `npm test` (ui)
- `npm test` (services/incident-svc)`

------
https://chatgpt.com/codex/tasks/task_e_68a05b01bab48323a9674d2bb84e3dd9