### PR TITLE
Add incident and warlog seeding scripts

### DIFF
--- a/services/incident-svc/package.json
+++ b/services/incident-svc/package.json
@@ -6,7 +6,8 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "node --test",
-    "migrate": "node migrate.js"
+    "migrate": "node migrate.js",
+    "seed": "node seed.js"
   },
   "dependencies": {
     "@tactix/lib-db": "workspace:*",

--- a/services/incident-svc/seed.js
+++ b/services/incident-svc/seed.js
@@ -1,0 +1,54 @@
+const path = require('path');
+try {
+  require('dotenv').config({ path: path.join(__dirname, '../../ops/env/incident.env') });
+} catch {}
+let createClient;
+try {
+  ({ createClient } = require('@tactix/lib-db'));
+} catch {
+  const { Client } = require('pg');
+  createClient = () => new Client({ connectionString: process.env.DATABASE_URL });
+}
+
+async function seed() {
+  const client = createClient();
+  await client.connect();
+  try {
+    const title = 'FOREST FIRE \u2013 LAC ST-JEAN';
+    const description = 'Wildfire reported near Lac St-Jean. Evacuation ongoing.';
+    const severity = 'high';
+
+    const { rows } = await client.query(
+      'INSERT INTO incidents (title, severity, description) VALUES ($1, $2, $3) RETURNING id',
+      [title, severity, description]
+    );
+    const incidentId = rows[0].id;
+
+    const logs = [
+      '16:30 Smoke spotted from watchtower.',
+      '16:45 Units dispatched to investigate.',
+      '17:10 Fire confirmed, size approx 3ha.',
+      '17:20 Evacuation of nearby campsite initiated.',
+      '17:45 Aerial support requested.',
+      '18:00 Firebreak construction underway.'
+    ];
+
+    for (const entry of logs) {
+      await client.query(
+        `INSERT INTO incident_events (incident_id, type, payload) VALUES ($1, 'COMMENT_ADDED', jsonb_build_object('comment', $2))`,
+        [incidentId, entry]
+      );
+      await client.query(
+        'UPDATE incidents SET comments = comments || $2::jsonb WHERE id = $1',
+        [incidentId, JSON.stringify([entry])]
+      );
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/warlog-svc/package.json
+++ b/services/warlog-svc/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"No tests\""
+    "test": "echo \"No tests\"",
+    "seed": "node seed.js"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/services/warlog-svc/seed.js
+++ b/services/warlog-svc/seed.js
@@ -1,0 +1,37 @@
+const path = require('path');
+try {
+  require('dotenv').config({ path: path.join(__dirname, '../../ops/env/warlog.env') });
+} catch {}
+const { Pool } = require('pg');
+
+async function seed() {
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    await pool.query(`CREATE TABLE IF NOT EXISTS warlog (
+      id SERIAL PRIMARY KEY,
+      author TEXT NOT NULL DEFAULT 'anonymous',
+      content TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );`);
+
+    const lines = [
+      '16:30 Smoke spotted from watchtower.',
+      '16:45 Units dispatched to investigate.',
+      '17:10 Fire confirmed, size approx 3ha.',
+      '17:20 Evacuation of nearby campsite initiated.',
+      '17:45 Aerial support requested.',
+      '18:00 Firebreak construction underway.'
+    ];
+
+    for (const content of lines) {
+      await pool.query('INSERT INTO warlog (author, content) VALUES ($1, $2)', ['system', content]);
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `seed` scripts for incident and warlog services
- populate demo incident "FOREST FIRE – LAC ST-JEAN" with six log entries

## Testing
- `pnpm test`
- `make seed` *(fails: Cannot find module 'pg' – dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a05d4ac3888323b717ecb5dba9f8e5