### PR TITLE
feat(ui): add bilingual localization

### DIFF
--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -1,9 +1,15 @@
 // React entry point for TACTIX UI
 // Uses Tailwind CSS for styling
 
+import LanguageSwitcher from './src/components/LanguageSwitcher.tsx';
+import i18n from './src/i18n/index.ts';
+import { formatTime } from './src/i18n/format.ts';
+
 const { useEffect, useState } = React;
+const { useTranslation, I18nextProvider } = ReactI18next;
 
 function App() {
+  const { t } = useTranslation();
   const [token, setToken] = useState(localStorage.getItem('token') || '');
   const [refreshToken, setRefreshToken] = useState(
     localStorage.getItem('refreshToken') || ''
@@ -50,7 +56,17 @@ function App() {
 
   return (
     <div className="p-4 space-y-4">
-      <h1 className="text-xl font-bold">TACTIX</h1>
+      <div className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">TACTIX</h1>
+        <div className="flex items-center gap-4">
+          <nav className="hidden sm:flex gap-4 text-sm">
+            <span>{t('nav.warlog')}</span>
+            <span>{t('nav.quickWarlogEntry')}</span>
+            <span>{t('nav.liveChat')}</span>
+          </nav>
+          <LanguageSwitcher />
+        </div>
+      </div>
       {view === 'login' && <Login onLogin={handleLogin} />}
       {view === 'list' && (
         <IncidentList
@@ -117,6 +133,7 @@ function Login({ onLogin }) {
 }
 
 function IncidentList({ token, onSelect, onLogout }) {
+  const { t } = useTranslation();
   const [incidents, setIncidents] = useState([]);
   const [title, setTitle] = useState('');
   const [severity, setSeverity] = useState('');
@@ -171,12 +188,12 @@ function IncidentList({ token, onSelect, onLogout }) {
       <form onSubmit={search} className="flex gap-2">
         <input
           className="border rounded p-1 flex-1"
-          placeholder="search"
+          placeholder={t('global.search')}
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
         />
         <button className="bg-gray-200 px-2 rounded" type="submit">
-          Search
+          {t('global.search')}
         </button>
       </form>
       <ul className="space-y-1">
@@ -227,6 +244,7 @@ function IncidentList({ token, onSelect, onLogout }) {
 }
 
 function IncidentDetail({ token, incidentId, onBack }) {
+  const { t } = useTranslation();
   const [incident, setIncident] = useState(null);
   const [comment, setComment] = useState('');
   const [warlog, setWarlog] = useState([]);
@@ -335,40 +353,52 @@ function IncidentDetail({ token, incidentId, onBack }) {
       {incident && (
         <div>
           <h2 className="text-lg font-semibold">{incident.title}</h2>
-          <p>Severity: {incident.severity}</p>
-          <p>Status: {incident.status}</p>
+          <p>
+            {t('global.severity')}: {incident.severity}
+          </p>
+          <p>
+            {t('global.status')}: {incident.status}
+          </p>
         </div>
       )}
       <div>
-        <h3 className="font-semibold">Warlog</h3>
+        <h3 className="font-semibold">{t('warlog.title')}</h3>
         <div className="bg-black text-green-200 p-2 rounded text-xs h-64 overflow-y-auto">
+          {warlog.length === 0 && <div>{t('warlog.empty')}</div>}
           {warlog.map((e, idx) => (
             <div
               key={idx}
               className="grid grid-cols-[auto_auto_1fr] gap-2 mb-1 whitespace-pre-wrap"
             >
-              <div className="text-gray-400">{e.time}</div>
+              <div className="text-gray-400">{e.time ? formatTime(new Date(e.time), i18n.language) : ''}</div>
               <div className="font-bold">{e.title}</div>
               <div>{e.text}</div>
             </div>
           ))}
         </div>
       </div>
-      <form onSubmit={submit} className="flex gap-2">
-        <input
-          className="border rounded p-1 flex-1"
-          placeholder="Add comment"
-          value={comment}
-          onChange={(e) => setComment(e.target.value)}
-        />
-        <button className="bg-blue-600 text-white px-3 rounded" type="submit">
-          Send
-        </button>
+      <form onSubmit={submit} className="flex flex-col gap-2">
+        <h3 className="font-semibold">{t('warlog.quickEntryTitle')}</h3>
+        <div className="flex gap-2">
+          <input
+            className="border rounded p-1 flex-1"
+            placeholder={t('chat.typingPlaceholder')}
+            value={comment}
+            onChange={(e) => setComment(e.target.value)}
+          />
+          <button className="bg-blue-600 text-white px-3 rounded" type="submit">
+            {t('chat.send')}
+          </button>
+        </div>
       </form>
     </div>
   );
 }
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+root.render(
+  <I18nextProvider i18n={i18n}>
+    <App />
+  </I18nextProvider>
+);
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,10 +7,35 @@
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
+    <script src="https://unpkg.com/i18next@23.7.6/i18next.min.js"></script>
+    <script src="https://unpkg.com/react-i18next@13.0.0/dist/umd/react-i18next.min.js"></script>
   </head>
   <body class="bg-gray-100 text-gray-800">
     <div id="root"></div>
-    <script type="text/babel" src="app.jsx"></script>
+    <script
+      type="text/babel"
+      data-type="module"
+      data-presets="typescript,react"
+      src="src/i18n/index.ts"
+    ></script>
+    <script
+      type="text/babel"
+      data-type="module"
+      data-presets="typescript"
+      src="src/i18n/format.ts"
+    ></script>
+    <script
+      type="text/babel"
+      data-type="module"
+      data-presets="typescript,react"
+      src="src/components/LanguageSwitcher.tsx"
+    ></script>
+    <script
+      type="text/babel"
+      data-type="module"
+      data-presets="typescript,react"
+      src="app.tsx"
+    ></script>
   </body>
 </html>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,11 +4,13 @@
   "private": true,
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"No tests\""
+    "test": "node tests/i18n.test.js"
   },
   "dependencies": {
     "express": "^4.18.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "i18next": "^23.7.6",
+    "react-i18next": "^13.0.0"
   }
 }

--- a/ui/src/components/LanguageSwitcher.tsx
+++ b/ui/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function LanguageSwitcher() {
+  const { t, i18n } = useTranslation();
+  const change = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lang = e.target.value;
+    i18n.changeLanguage(lang);
+    localStorage.setItem('tactix.lang', lang);
+  };
+
+  return (
+    <select
+      aria-label={t('nav.language')}
+      value={i18n.language}
+      onChange={change}
+      className="border rounded p-1 text-sm"
+    >
+      <option value="en">{t('nav.english')}</option>
+      <option value="fr">{t('nav.french')}</option>
+    </select>
+  );
+}

--- a/ui/src/i18n/format.ts
+++ b/ui/src/i18n/format.ts
@@ -1,0 +1,10 @@
+export function formatTime(date: Date, lang: string) {
+  return new Intl.DateTimeFormat(lang, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit'
+  }).format(date);
+}

--- a/ui/src/i18n/index.ts
+++ b/ui/src/i18n/index.ts
@@ -1,0 +1,22 @@
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en/common.json';
+import fr from './locales/fr/common.json';
+
+const saved = localStorage.getItem('tactix.lang');
+const browser = navigator.language && navigator.language.startsWith('fr') ? 'fr' : 'en';
+const lang = saved || browser;
+
+void i18next
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr }
+    },
+    lng: lang,
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false }
+  });
+
+export default i18next;

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -1,0 +1,30 @@
+{
+  "nav": {
+    "warlog": "Warlog",
+    "quickWarlogEntry": "Quick Warlog Entry",
+    "liveChat": "Live Chat",
+    "save": "Save",
+    "chatPlaceholder": "Chat...",
+    "language": "Language",
+    "english": "English",
+    "french": "Français"
+  },
+  "warlog": {
+    "title": "Warlog",
+    "empty": "No entries yet.",
+    "quickEntryTitle": "Quick Warlog Entry"
+  },
+  "chat": {
+    "title": "Live Chat",
+    "empty": "No messages yet.",
+    "send": "Send",
+    "typingPlaceholder": "Chat..."
+  },
+  "global": {
+    "loading": "Loading…",
+    "error": "Something went wrong.",
+    "search": "Search",
+    "status": "Status",
+    "severity": "Severity"
+  }
+}

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -1,0 +1,30 @@
+{
+  "nav": {
+    "warlog": "Journal de guerre",
+    "quickWarlogEntry": "Entrée rapide de journal",
+    "liveChat": "Chat en direct",
+    "save": "Enregistrer",
+    "chatPlaceholder": "Discussion...",
+    "language": "Langue",
+    "english": "Anglais",
+    "french": "Français"
+  },
+  "warlog": {
+    "title": "Journal de guerre",
+    "empty": "Aucune entrée pour le moment.",
+    "quickEntryTitle": "Entrée rapide au journal"
+  },
+  "chat": {
+    "title": "Chat en direct",
+    "empty": "Aucun message pour le moment.",
+    "send": "Envoyer",
+    "typingPlaceholder": "Discussion..."
+  },
+  "global": {
+    "loading": "Chargement…",
+    "error": "Une erreur est survenue.",
+    "search": "Recherche",
+    "status": "Statut",
+    "severity": "Gravité"
+  }
+}

--- a/ui/tests/i18n.test.js
+++ b/ui/tests/i18n.test.js
@@ -1,0 +1,32 @@
+const React = require('react');
+const ReactDOMServer = require('react-dom/server');
+const i18next = require('i18next');
+const { I18nextProvider, initReactI18next, useTranslation } = require('react-i18next');
+const en = require('../src/i18n/locales/en/common.json');
+const fr = require('../src/i18n/locales/fr/common.json');
+const assert = require('assert');
+
+i18next.use(initReactI18next).init({
+  resources: { en: { translation: en }, fr: { translation: fr } },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false }
+});
+
+function Comp() {
+  const { t } = useTranslation();
+  return React.createElement('span', null, t('nav.language'));
+}
+
+let html = ReactDOMServer.renderToString(
+  React.createElement(I18nextProvider, { i18n }, React.createElement(Comp))
+);
+assert(html.includes('Language'));
+
+i18next.changeLanguage('fr');
+html = ReactDOMServer.renderToString(
+  React.createElement(I18nextProvider, { i18n }, React.createElement(Comp))
+);
+assert(html.includes('Langue'));
+
+console.log('i18n test passed');


### PR DESCRIPTION
## Summary
- add English and French translation files and i18n bootstrap
- add language switcher with persistence
- localize warlog, chat, search, status and severity labels
- include simple React test for language toggle

## Testing
- `pnpm -r install` (fails: GET https://registry.npmjs.org/@types%2Fnode: Forbidden - 403)
- `pnpm -r build` (fails: Cannot find module 'pg' or its corresponding type declarations)
- `pnpm --prefix ui test` (fails: Cannot find module 'i18next')
- `docker compose up --build` (fails: command not found: docker)


------
https://chatgpt.com/codex/tasks/task_e_68a062d7193c83239d11c0265ba2a46b