### PR TITLE
feat: demo-ready incident and realtime stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,66 +1,19 @@
 version: "3.9"
 services:
-  gateway:
-    image: nginx:stable
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: tactix
+      POSTGRES_PASSWORD: tactix
+      POSTGRES_DB: tactix
     volumes:
-      - ./ops/nginx.conf:/etc/nginx/nginx.conf:ro
-    ports:
-      - "80:80"
-    depends_on:
-      - auth-svc
-      - incident-svc
-      - realtime-svc
-      - warlog-svc
-      - tak-ingest-svc
-      - ui
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-  auth-svc:
-    build: ./services/auth-svc
-    env_file:
-      - ./ops/env/auth.env
-    depends_on:
-      - postgres
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
+      - pgdata:/var/lib/postgresql/data
   incident-svc:
     build: ./services/incident-svc
     env_file:
       - ./ops/env/incident.env
     depends_on:
       - postgres
-      - opensearch
-      - minio
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-  warlog-svc:
-    build: ./services/warlog-svc
-    env_file:
-      - ./ops/env/warlog.env
-    depends_on:
-      - postgres
-      - opensearch
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 5s
-      timeout: 5s
-      retries: 5
-  tak-ingest-svc:
-    build: ./services/tak-ingest-svc
-    env_file:
-      - ./ops/env/tak.env
-    depends_on:
-      - postgres
-      - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 5s
@@ -70,8 +23,6 @@ services:
     build: ./services/realtime-svc
     env_file:
       - ./ops/env/realtime.env
-    depends_on:
-      - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
       interval: 5s
@@ -79,40 +30,20 @@ services:
       retries: 5
   ui:
     build: ./ui
-  postgres:
-    image: postgres:16
-    environment:
-      POSTGRES_USER: tactix
-      POSTGRES_PASSWORD: tactix
-      POSTGRES_DB: tactix
+  gateway:
+    image: nginx:stable
     volumes:
-      - pgdata:/var/lib/postgresql/data
-      - ./ops/postgres/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
-  redis:
-    image: redis:7
-    command: ["redis-server", "--appendonly", "yes"]
-    volumes:
-      - redisdata:/data
-  opensearch:
-    image: opensearchproject/opensearch:2
-    environment:
-      discovery.type: single-node
-      plugins.security.disabled: "true"
-    volumes:
-      - osdata:/usr/share/opensearch/data
-  minio:
-    image: minio/minio
-    command: server /data --console-address ":9001"
-    environment:
-      MINIO_ROOT_USER: tactix
-      MINIO_ROOT_PASSWORD: tactix-secret
+      - ./ops/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "9000:9000"
-      - "9001:9001"
-    volumes:
-      - miniodata:/data
+      - "80:80"
+    depends_on:
+      - incident-svc
+      - realtime-svc
+      - ui
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 volumes:
   pgdata: {}
-  redisdata: {}
-  osdata: {}
-  miniodata: {}

--- a/ops/env/incident.env
+++ b/ops/env/incident.env
@@ -1,7 +1,3 @@
 PORT=3000
 DATABASE_URL=postgres://tactix:tactix@postgres:5432/tactix
-MINIO_ENDPOINT=minio
-MINIO_PORT=9000
-MINIO_ACCESS_KEY=tactix
-MINIO_SECRET_KEY=tactix-secret
-MINIO_BUCKET=tactix
+REALTIME_URL=http://realtime-svc:3000/events

--- a/ops/env/realtime.env
+++ b/ops/env/realtime.env
@@ -1,2 +1,1 @@
 PORT=3000
-REDIS_URL=redis://redis:6379

--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -2,7 +2,6 @@ events {}
 http {
   server {
     listen 80;
-    proxy_set_header Authorization $http_authorization;
 
     location /health {
       return 200 '{"ok": true}';
@@ -13,36 +12,12 @@ http {
       proxy_pass http://ui:3000/;
     }
 
-    location /api/auth/ {
-      proxy_pass http://auth-svc:3000/;
-    }
-
-    location /api/warlog/ {
-      if ($http_authorization = "") {
-        return 401;
-      }
-      proxy_pass http://warlog-svc:3000/;
-    }
-
-    location /api/tak/ {
-      if ($http_authorization = "") {
-        return 401;
-      }
-      proxy_pass http://tak-ingest-svc:3000/;
-    }
-
     location /api/ {
-      if ($http_authorization = "") {
-        return 401;
-      }
       proxy_pass http://incident-svc:3000/;
     }
 
-    location /rt/ {
-      if ($http_authorization = "") {
-        return 401;
-      }
-      proxy_pass http://realtime-svc:3000/;
+    location /rt {
+      proxy_pass http://realtime-svc:3000/rt;
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "Upgrade";

--- a/services/incident-svc/package.json
+++ b/services/incident-svc/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",
-    "test": "node --test",
+    "test": "NODE_ENV=test node --test",
     "migrate": "node migrate.js",
     "seed": "node seed.js"
   },

--- a/services/realtime-svc/index.js
+++ b/services/realtime-svc/index.js
@@ -2,88 +2,25 @@ require('dotenv').config();
 const express = require('express');
 const http = require('http');
 const WebSocket = require('ws');
-const { createClient } = require('@tactix/lib-db');
 
 const PORT = process.env.PORT || 3000;
-const INCIDENT_SVC_URL = process.env.INCIDENT_SVC_URL || 'http://incident-svc:3000';
-const MAX_QUEUE = 100;
 
 const app = express();
+app.use(express.json());
 app.get('/health', (_req, res) => res.json({ ok: true }));
+app.post('/events', (req, res) => {
+  const event = req.body;
+  broadcast(event);
+  res.json({ ok: true });
+});
 
 const server = http.createServer(app);
-const wss = new WebSocket.Server({ noServer: true });
-
-server.on('upgrade', (req, socket, head) => {
-  if (req.url === '/rt') {
-    wss.handleUpgrade(req, socket, head, (ws) => {
-      wss.emit('connection', ws, req);
-    });
-  } else {
-    socket.destroy();
-  }
-});
-
-server.listen(PORT, () => {
-  console.log(`realtime-svc listening on ${PORT}`);
-});
-
-const db = createClient();
-db.connect()
-  .then(() => db.query('LISTEN tactix_events'))
-  .catch((err) => console.error('db connect failed', err));
-
-db.on('notification', (msg) => {
-  try {
-    const event = JSON.parse(msg.payload);
-    broadcast(event);
-  } catch (e) {
-    console.error('invalid payload', e);
-  }
-});
+const wss = new WebSocket.Server({ server, path: '/rt' });
 
 const clients = new Map();
 
-function broadcast(event) {
-  for (const [ws, state] of clients.entries()) {
-    if (state.incidentId === event.incidentId) {
-      enqueue(ws, state, event);
-    }
-  }
-}
-
-function enqueue(ws, state, event) {
-  if (state.queue.length >= MAX_QUEUE) {
-    fetch(`${INCIDENT_SVC_URL}/incidents/${state.incidentId}`)
-      .then((res) => res.json())
-      .then((incident) => {
-        ws.send(JSON.stringify({ type: 'snapshot', incident, seq: event.seq }));
-      })
-      .catch(() => {});
-    state.queue = [];
-    return;
-  }
-  state.queue.push(event);
-  flush(ws, state);
-}
-
-function flush(ws, state) {
-  if (state.sending || ws.readyState !== WebSocket.OPEN) return;
-  const msg = state.queue.shift();
-  if (!msg) return;
-  state.sending = true;
-  ws.send(JSON.stringify(msg), (err) => {
-    state.sending = false;
-    if (err) {
-      ws.close();
-    } else {
-      flush(ws, state);
-    }
-  });
-}
-
 wss.on('connection', (ws) => {
-  const state = { incidentId: null, queue: [], sending: false };
+  const state = { incidentId: null };
   clients.set(ws, state);
 
   ws.on('message', (data) => {
@@ -95,20 +32,23 @@ wss.on('connection', (ws) => {
     }
     if (msg.type === 'subscribe' && typeof msg.incidentId === 'number') {
       state.incidentId = msg.incidentId;
-      if (typeof msg.seq === 'number') {
-        fetch(`${INCIDENT_SVC_URL}/incidents/${state.incidentId}`)
-          .then((res) => res.json())
-          .then((incident) => {
-            ws.send(
-              JSON.stringify({ type: 'snapshot', incident, seq: msg.seq })
-            );
-          })
-          .catch(() => {});
-      }
     }
   });
 
-  ws.on('close', () => {
-    clients.delete(ws);
-  });
+  ws.on('close', () => clients.delete(ws));
+});
+
+function broadcast(event) {
+  const msg = JSON.stringify(event);
+  for (const [ws, state] of clients.entries()) {
+    if (state.incidentId === null || state.incidentId === event.incidentId) {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(msg);
+      }
+    }
+  }
+}
+
+server.listen(PORT, () => {
+  console.log(`realtime-svc listening on ${PORT}`);
 });

--- a/services/realtime-svc/package.json
+++ b/services/realtime-svc/package.json
@@ -7,7 +7,6 @@
     "test": "echo \"No tests\""
   },
   "dependencies": {
-    "@tactix/lib-db": "workspace:*",
     "express": "^4.18.2",
     "ws": "^8.13.0",
     "dotenv": "^16.4.5"

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -1,290 +1,32 @@
-// React entry point for TACTIX UI
-// Uses Tailwind CSS for styling
-
-import LanguageSwitcher from './src/components/LanguageSwitcher.tsx';
-import i18n from './src/i18n/index.ts';
-import { formatTime } from './src/i18n/format.ts';
-
-const { useEffect, useState, useRef } = React;
-const { useTranslation, I18nextProvider } = ReactI18next;
+const { useState, useEffect } = React;
 
 function App() {
-  const { t } = useTranslation();
-  const [token, setToken] = useState(localStorage.getItem('token') || '');
-  const [refreshToken, setRefreshToken] = useState(
-    localStorage.getItem('refreshToken') || ''
-  );
-  const [view, setView] = useState(token ? 'list' : 'login');
-  const [detailId, setDetailId] = useState(null);
-
-  function handleLogin(data) {
-    setToken(data.token);
-    setRefreshToken(data.refreshToken);
-    localStorage.setItem('token', data.token);
-    localStorage.setItem('refreshToken', data.refreshToken);
-    setView('list');
-  }
-
-  function logout() {
-    setToken('');
-    setRefreshToken('');
-    localStorage.removeItem('token');
-    localStorage.removeItem('refreshToken');
-    setView('login');
-  }
-
-  // Periodically refresh JWT using refresh token
-  useEffect(() => {
-    if (!refreshToken) return;
-    const id = setInterval(() => {
-      fetch('/auth/refresh', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ refreshToken }),
-      })
-        .then((res) => (res.ok ? res.json() : Promise.reject()))
-        .then((data) => {
-          setToken(data.token);
-          setRefreshToken(data.refreshToken);
-          localStorage.setItem('token', data.token);
-          localStorage.setItem('refreshToken', data.refreshToken);
-        })
-        .catch(() => logout());
-    }, 10 * 60 * 1000); // refresh every 10 minutes
-    return () => clearInterval(id);
-  }, [refreshToken]);
-
-  return (
-    <div className="p-4 space-y-4">
-      <div className="flex justify-between items-center">
-        <h1 className="text-xl font-bold">TACTIX</h1>
-        <div className="flex items-center gap-4">
-          <nav className="hidden sm:flex gap-4 text-sm">
-            <span>{t('nav.warlog')}</span>
-            <span>{t('nav.quickWarlogEntry')}</span>
-            <span>{t('nav.liveChat')}</span>
-          </nav>
-          <LanguageSwitcher />
-        </div>
-      </div>
-      {view === 'login' && <Login onLogin={handleLogin} />}
-      {view === 'list' && (
-        <IncidentList
-          token={token}
-          onSelect={(id) => {
-            setDetailId(id);
-            setView('detail');
-          }}
-          onLogout={logout}
-        />
-      )}
-      {view === 'detail' && (
-        <IncidentDetail
-          token={token}
-          incidentId={detailId}
-          onBack={() => setView('list')}
-        />
-      )}
-    </div>
-  );
-}
-
-function Login({ onLogin }) {
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-
-  const submit = (e) => {
-    e.preventDefault();
-    fetch('/auth/login', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ username, password }),
-    })
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then(onLogin)
-      .catch(() => setError('Login failed'));
-  };
-
-  return (
-    <form onSubmit={submit} className="space-y-2 max-w-sm">
-      {error && <div className="text-red-600 text-sm">{error}</div>}
-      <input
-        className="border rounded p-1 w-full"
-        placeholder="username"
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
-      />
-      <input
-        className="border rounded p-1 w-full"
-        type="password"
-        placeholder="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
-      <button
-        className="bg-blue-600 text-white px-3 py-1 rounded"
-        type="submit"
-      >
-        Login
-      </button>
-    </form>
-  );
-}
-
-function IncidentList({ token, onSelect, onLogout }) {
-  const { t } = useTranslation();
   const [incidents, setIncidents] = useState([]);
-  const [title, setTitle] = useState('');
-  const [severity, setSeverity] = useState('');
-  const [description, setDescription] = useState('');
-  const [searchInput, setSearchInput] = useState('');
-  const [q, setQ] = useState('');
-
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  const [selected, setSelected] = useState(null);
+  const [incident, setIncident] = useState(null);
+  const [warlog, setWarlog] = useState([]);
+  const [comment, setComment] = useState('');
 
   useEffect(() => {
-    let url = '/incidents';
-    if (q) url += `?q=${encodeURIComponent(q)}`;
-    fetch(url, { headers })
+    fetch('/api/incidents')
       .then((res) => res.json())
       .then(setIncidents)
       .catch(() => setIncidents([]));
-  }, [q, token]);
-
-  const createIncident = (e) => {
-    e.preventDefault();
-    fetch('/incidents', {
-      method: 'POST',
-      headers: { ...headers, 'content-type': 'application/json' },
-      body: JSON.stringify({ title, severity, description }),
-    })
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((incident) => {
-        setTitle('');
-        setSeverity('');
-        setDescription('');
-        onSelect(incident.id);
-      })
-      .catch(() => {});
-  };
-
-  const search = (e) => {
-    e.preventDefault();
-    setQ(searchInput);
-  };
-
-  return (
-    <div className="space-y-4">
-      <div className="flex justify-between items-center">
-        <h2 className="text-lg font-semibold">Incidents</h2>
-        <button
-          className="text-sm text-blue-600 underline"
-          onClick={onLogout}
-        >
-          Logout
-        </button>
-      </div>
-      <form onSubmit={search} className="flex gap-2">
-        <input
-          className="border rounded p-1 flex-1"
-          placeholder={t('global.search')}
-          value={searchInput}
-          onChange={(e) => setSearchInput(e.target.value)}
-        />
-        <button className="bg-gray-200 px-2 rounded" type="submit">
-          {t('global.search')}
-        </button>
-      </form>
-      <ul className="space-y-1">
-        {incidents.map((i) => (
-          <li key={i.id}>
-            <button
-              className="text-blue-600 underline"
-              onClick={() => onSelect(i.id)}
-            >
-              {i.title} – {i.status}
-            </button>
-          </li>
-        ))}
-      </ul>
-      <div>
-        <h3 className="font-semibold">Create Incident</h3>
-        <form onSubmit={createIncident} className="space-y-2 max-w-md">
-          <input
-            className="border rounded p-1 w-full"
-            placeholder="title"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            required
-          />
-          <input
-            className="border rounded p-1 w-full"
-            placeholder="severity"
-            value={severity}
-            onChange={(e) => setSeverity(e.target.value)}
-            required
-          />
-          <textarea
-            className="border rounded p-1 w-full"
-            placeholder="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-          />
-          <button
-            className="bg-blue-600 text-white px-3 py-1 rounded"
-            type="submit"
-          >
-            Create
-          </button>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-function IncidentDetail({ token, incidentId, onBack }) {
-  const { t } = useTranslation();
-  const [incident, setIncident] = useState(null);
-  const [comment, setComment] = useState('');
-  const [warlog, setWarlog] = useState([]);
-  const logRef = useRef<HTMLDivElement | null>(null);
-
-  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  }, []);
 
   useEffect(() => {
-    fetch(`/incidents/${incidentId}`, { headers })
+    if (selected === null) return;
+    fetch(`/api/incidents/${selected}`)
       .then((res) => res.json())
       .then((data) => {
         setIncident(data);
-        const log = [
-          {
-            time: new Date(data.createdAt).toISOString(),
-            title: 'CREATED',
-            text: data.title,
-          },
-          ...data.comments.map((c) => ({
-            time: '',
-            title: 'COMMENT',
-            text: c,
-          })),
-        ];
-        setWarlog(log);
+        setWarlog(data.comments || []);
       });
-  }, [incidentId]);
 
-  useEffect(() => {
-    const div = logRef.current;
-    if (div) {
-      div.scrollTop = div.scrollHeight;
-    }
-  }, [warlog]);
-
-  useEffect(() => {
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
     const ws = new WebSocket(`${protocol}://${window.location.host}/rt`);
     ws.onopen = () => {
-      ws.send(JSON.stringify({ type: 'subscribe', incidentId }));
+      ws.send(JSON.stringify({ type: 'subscribe', incidentId: selected }));
     };
     ws.onmessage = (evt) => {
       let msg;
@@ -293,123 +35,67 @@ function IncidentDetail({ token, incidentId, onBack }) {
       } catch {
         return;
       }
-      if (msg.type === 'snapshot') {
-        setIncident(msg.incident);
-        const log = [
-          {
-            time: new Date(msg.incident.createdAt).toISOString(),
-            title: 'CREATED',
-            text: msg.incident.title,
-          },
-          ...msg.incident.comments.map((c) => ({
-            time: '',
-            title: 'COMMENT',
-            text: c,
-          })),
-        ];
-        setWarlog(log);
-      } else if (msg.type === 'COMMENT_ADDED') {
-        setIncident((prev) => ({
-          ...prev,
-          comments: [...(prev?.comments || []), msg.payload.comment],
-        }));
-        setWarlog((prev) => [
-          ...prev,
-          {
-            time: new Date().toISOString(),
-            title: 'COMMENT',
-            text: msg.payload.comment,
-          },
-        ]);
-      } else if (msg.type === 'STATUS_CHANGED') {
-        setWarlog((prev) => [
-          ...prev,
-          {
-            time: new Date().toISOString(),
-            title: 'STATUS',
-            text: msg.payload.status,
-          },
-        ]);
-      } else if (msg.type === 'CREATED') {
-        setWarlog((prev) => [
-          ...prev,
-          {
-            time: new Date().toISOString(),
-            title: 'CREATED',
-            text: msg.payload.title,
-          },
-        ]);
+      if (msg.type === 'COMMENT_ADDED' && msg.incidentId === selected) {
+        setWarlog((prev) => [...prev, msg.text]);
       }
     };
     return () => ws.close();
-  }, [incidentId]);
+  }, [selected]);
 
   const submit = (e) => {
     e.preventDefault();
-    fetch(`/incidents/${incidentId}/comment`, {
+    fetch(`/api/incidents/${selected}/comment`, {
       method: 'POST',
-      headers: { ...headers, 'content-type': 'application/json' },
+      headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ comment }),
     }).then(() => setComment(''));
   };
 
+  if (selected === null) {
+    return (
+      <div className="p-4 space-y-2">
+        <h1 className="text-xl font-bold">Incidents</h1>
+        <ul className="list-disc pl-4">
+          {incidents.map((i) => (
+            <li key={i.id}>
+              <button
+                className="text-blue-600 underline"
+                onClick={() => setSelected(i.id)}
+              >
+                {i.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
-      <button className="text-blue-600 underline" onClick={onBack}>
+    <div className="p-4 space-y-4">
+      <button className="text-blue-600 underline" onClick={() => setSelected(null)}>
         &larr; Back
       </button>
-      {incident && (
-        <div>
-          <h2 className="text-lg font-semibold">{incident.title}</h2>
-          <p>
-            {t('global.severity')}: {incident.severity}
-          </p>
-          <p>
-            {t('global.status')}: {incident.status}
-          </p>
-        </div>
-      )}
-      <div>
-        <h3 className="font-semibold">{t('warlog.title')}</h3>
-        <div
-          ref={logRef}
-          className="bg-black text-green-200 p-2 rounded text-xs h-64 overflow-y-auto"
-        >
-          {warlog.length === 0 && <div>{t('warlog.empty')}</div>}
-          {warlog.map((e, idx) => (
-            <div
-              key={idx}
-              className="grid grid-cols-[auto_auto_1fr] gap-2 mb-1 whitespace-pre-wrap"
-            >
-              <div className="text-gray-400">{e.time ? formatTime(new Date(e.time), i18n.language) : ''}</div>
-              <div className="font-bold">{e.title}</div>
-              <div>{e.text}</div>
-            </div>
-          ))}
-        </div>
+      {incident && <h2 className="text-lg font-semibold">{incident.title}</h2>}
+      <div className="bg-black text-green-200 p-2 rounded h-64 overflow-y-auto">
+        {warlog.map((c, idx) => (
+          <div key={idx} className="mb-1 whitespace-pre-wrap">
+            {c}
+          </div>
+        ))}
       </div>
-      <form onSubmit={submit} className="flex flex-col gap-2">
-        <h3 className="font-semibold">{t('warlog.quickEntryTitle')}</h3>
-        <div className="flex gap-2">
-          <input
-            className="border rounded p-1 flex-1"
-            placeholder={t('chat.typingPlaceholder')}
-            value={comment}
-            onChange={(e) => setComment(e.target.value)}
-          />
-          <button className="bg-blue-600 text-white px-3 rounded" type="submit">
-            {t('chat.send')}
-          </button>
-        </div>
+      <form onSubmit={submit} className="flex gap-2">
+        <textarea
+          className="border rounded p-1 flex-1"
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+        />
+        <button className="bg-blue-600 text-white px-3 rounded" type="submit">
+          Save
+        </button>
       </form>
     </div>
   );
 }
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(
-  <I18nextProvider i18n={i18n}>
-    <App />
-  </I18nextProvider>
-);
-
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,29 +7,9 @@
     <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
     <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
     <script src="https://unpkg.com/@babel/standalone@7/babel.min.js"></script>
-    <script src="https://unpkg.com/i18next@23.7.6/i18next.min.js"></script>
-    <script src="https://unpkg.com/react-i18next@13.0.0/dist/umd/react-i18next.min.js"></script>
   </head>
   <body class="bg-gray-100 text-gray-800">
     <div id="root"></div>
-    <script
-      type="text/babel"
-      data-type="module"
-      data-presets="typescript,react"
-      src="src/i18n/index.ts"
-    ></script>
-    <script
-      type="text/babel"
-      data-type="module"
-      data-presets="typescript"
-      src="src/i18n/format.ts"
-    ></script>
-    <script
-      type="text/babel"
-      data-type="module"
-      data-presets="typescript,react"
-      src="src/components/LanguageSwitcher.tsx"
-    ></script>
     <script
       type="text/babel"
       data-type="module"

--- a/ui/tests/i18n.test.js
+++ b/ui/tests/i18n.test.js
@@ -12,6 +12,7 @@ i18next.use(initReactI18next).init({
   fallbackLng: 'en',
   interpolation: { escapeValue: false }
 });
+const i18n = i18next;
 
 function Comp() {
   const { t } = useTranslation();


### PR DESCRIPTION
## Summary
- seed a demo incident and broadcast comment events from incident-svc
- add lightweight realtime-svc with /rt websocket and /events publish endpoint
- strip auth and extra services from gateway, UI and docker-compose for UAT

## Testing
- `pnpm --filter incident-svc test`
- `npm test` (realtime-svc)
- `npm test` (ui)
- `pnpm install` *(fails: GET https://registry.npmjs.org/@types%2Fnode: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a069286e708323bc2c925dcac7d97b