### PR TITLE
feat: add messaging workflow

### DIFF
--- a/packages/lib-db/src/index.ts
+++ b/packages/lib-db/src/index.ts
@@ -1,8 +1,9 @@
-import { Client } from 'pg';
+import pkg from 'pg';
 import fs from 'fs';
 import path from 'path';
 
-export { Client };
+export const { Client } = pkg as any;
+export type Client = any;
 
 export function createClient(): Client {
   return new Client({
@@ -10,7 +11,10 @@ export function createClient(): Client {
   });
 }
 
-export async function runMigrations(client: Client, migrationsDir: string): Promise<void> {
+export async function runMigrations(
+  client: any,
+  migrationsDir: string
+): Promise<void> {
   const files = fs.existsSync(migrationsDir)
     ? fs.readdirSync(migrationsDir).sort()
     : [];

--- a/services/incident-svc/migrations/down/011_drop_messages.sql
+++ b/services/incident-svc/migrations/down/011_drop_messages.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS messages;

--- a/services/incident-svc/migrations/down/012_drop_org_units.sql
+++ b/services/incident-svc/migrations/down/012_drop_org_units.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS org_units;

--- a/services/incident-svc/migrations/up/011_create_messages.sql
+++ b/services/incident-svc/migrations/up/011_create_messages.sql
@@ -1,0 +1,12 @@
+CREATE TABLE messages (
+  message_id UUID PRIMARY KEY,
+  operation_id UUID REFERENCES operations(operation_id),
+  author_upn TEXT NOT NULL,
+  recipient_scope TEXT NOT NULL,
+  recipient_unit TEXT,
+  status TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX idx_messages_operation ON messages(operation_id);

--- a/services/incident-svc/migrations/up/012_create_org_units.sql
+++ b/services/incident-svc/migrations/up/012_create_org_units.sql
@@ -1,0 +1,8 @@
+CREATE TABLE org_units (
+  org_unit_id UUID PRIMARY KEY,
+  operation_id UUID REFERENCES operations(operation_id),
+  scope TEXT NOT NULL,
+  unit_name TEXT NOT NULL,
+  xmpp_jid TEXT
+);
+CREATE INDEX idx_org_units_operation ON org_units(operation_id);

--- a/services/incident-svc/src/index.ts
+++ b/services/incident-svc/src/index.ts
@@ -9,6 +9,7 @@ declare const process: any;
 declare const Buffer: any;
 declare function require(name: string): any;
 declare const module: any;
+declare function fetch(input: any, init?: any): Promise<any>;
 
 export interface Incident {
   id: number;
@@ -117,6 +118,33 @@ async function readMultipart(
     });
     req.on('error', reject);
   });
+}
+
+async function sendXmppMessage(jid: string, content: string) {
+  if (!process.env.XMPP_URL) return;
+  try {
+    await fetch(process.env.XMPP_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jid, content }),
+    });
+  } catch (_) {
+    /* ignore */
+  }
+}
+
+async function logWarlog(author: string, content: string) {
+  const url = process.env.WARLOG_URL;
+  if (!url) return;
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ author, content }),
+    });
+  } catch (_) {
+    /* ignore */
+  }
 }
 
 function json(res: http.ServerResponse, code: number, body: any) {
@@ -366,6 +394,95 @@ export function createServer() {
           )
         ).rows[0];
         return json(res, 201, row);
+      });
+    }
+
+    const orgMatch = url.pathname.match(/^\/operations\/([^/]+)\/org-units$/);
+    if (req.method === 'GET' && orgMatch && dbClient) {
+      const opId = orgMatch[1];
+      const { rows } = await dbClient.query(
+        'SELECT org_unit_id, scope, unit_name, xmpp_jid FROM org_units WHERE operation_id=$1',
+        [opId]
+      );
+      return json(res, 200, rows);
+    }
+
+    const msgMatch = url.pathname.match(/^\/operations\/([^/]+)\/messages$/);
+    if (msgMatch && dbClient) {
+      const opId = msgMatch[1];
+      if (req.method === 'POST') {
+        return requireAuth(req as AuthenticatedRequest, res, async () => {
+          const body = await readBody(req).catch(() => null);
+          if (!body || !body.recipientScope || !body.content) {
+            return json(res, 400, {
+              error: 'recipientScope and content required',
+            });
+          }
+          const id = randomUUID();
+          const row = (
+            await dbClient.query(
+              'INSERT INTO messages (message_id, operation_id, author_upn, recipient_scope, recipient_unit, status, content) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *',
+              [
+                id,
+                opId,
+                (req as AuthenticatedRequest).user!.sub,
+                body.recipientScope,
+                body.recipientUnit || null,
+                'DRAFT',
+                body.content,
+              ]
+            )
+          ).rows[0];
+          return json(res, 201, row);
+        });
+      }
+      if (req.method === 'GET') {
+        return requireAuth(req as AuthenticatedRequest, res, async () => {
+          const status = url.searchParams.get('status');
+          const params: any[] = [opId];
+          let sql = 'SELECT * FROM messages WHERE operation_id=$1';
+          if (status) {
+            params.push(status);
+            sql += ' AND status=$2';
+            if (status === 'DRAFT') {
+              params.push((req as AuthenticatedRequest).user!.sub);
+              sql += ' AND author_upn=$3';
+            }
+          }
+          const { rows } = await dbClient.query(sql, params);
+          return json(res, 200, rows);
+        });
+      }
+    }
+
+    const submitMatch = url.pathname.match(
+      /^\/operations\/([^/]+)\/messages\/([^/]+)\/submit$/
+    );
+    if (req.method === 'PUT' && submitMatch && dbClient) {
+      const opId = submitMatch[1];
+      const msgId = submitMatch[2];
+      return requireAuth(req as AuthenticatedRequest, res, async () => {
+        const { rows } = await dbClient.query(
+          'UPDATE messages SET status=$1, updated_at=now() WHERE message_id=$2 AND operation_id=$3 RETURNING *',
+          ['SUBMITTED', msgId, opId]
+        );
+        if (!rows.length) return json(res, 404, {});
+        const msg = rows[0];
+        try {
+          const r = await dbClient.query(
+            'SELECT xmpp_jid FROM org_units WHERE operation_id=$1 AND scope=$2 AND unit_name=$3',
+            [opId, msg.recipient_scope, msg.recipient_unit]
+          );
+          const jid = r.rows[0]?.xmpp_jid;
+          if (jid) await sendXmppMessage(jid, msg.content);
+        } catch (_) {}
+        try {
+          await logWarlog(
+            msg.author_upn,
+            `Message submitted to ${msg.recipient_unit || msg.recipient_scope}`
+          );
+        } catch (_) {}
+        return json(res, 200, msg);
       });
     }
 

--- a/services/incident-svc/test/messages.test.js
+++ b/services/incident-svc/test/messages.test.js
@@ -1,0 +1,66 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const path = require('path');
+const { newDb } = require('pg-mem');
+const { runMigrations } = require('@tactix/lib-db');
+const { createServer, setClient } = require('../dist/index.js');
+
+async function setupDb() {
+  const db = newDb();
+  const pg = db.adapters.createPg();
+  const client = new pg.Client();
+  await client.connect();
+  await runMigrations(client, path.join(__dirname, '../migrations/up'));
+  return client;
+}
+
+test('message lifecycle', async () => {
+  const client = await setupDb();
+  const opId = '11111111-1111-1111-1111-111111111111';
+  await client.query('INSERT INTO operations (operation_id, code, title) VALUES ($1,$2,$3)', [opId, 'OPX', 'Op X']);
+  await client.query('INSERT INTO org_units (org_unit_id, operation_id, scope, unit_name, xmpp_jid) VALUES ($1,$2,$3,$4,$5)', [
+    '22222222-2222-2222-2222-222222222222',
+    opId,
+    'HIGHER',
+    'Battalion HQ',
+    'jid:hq'
+  ]);
+  setClient(client);
+
+  const token = Buffer.from(JSON.stringify({ sub: 'user1' })).toString('base64');
+  const server = createServer().listen(0);
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  let res = await fetch(`${base}/operations/${opId}/messages`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({ recipientScope: 'HIGHER', recipientUnit: 'Battalion HQ', content: 'Hello' })
+  });
+  assert.equal(res.status, 201);
+  const draft = await res.json();
+
+  res = await fetch(`${base}/operations/${opId}/messages?status=DRAFT`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const drafts = await res.json();
+  assert.equal(drafts.length, 1);
+
+  res = await fetch(`${base}/operations/${opId}/messages/${draft.message_id}/submit`, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  assert.equal(res.status, 200);
+  const submitted = await res.json();
+  assert.equal(submitted.status, 'SUBMITTED');
+
+  res = await fetch(`${base}/operations/${opId}/messages`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const msgs = await res.json();
+  assert.equal(msgs.length, 1);
+
+  server.close();
+});

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -2,6 +2,7 @@
 // Uses Tailwind CSS for styling
 
 import LanguageSwitcher from './src/components/LanguageSwitcher.tsx';
+import NewMessageCard from './src/components/NewMessageCard.tsx';
 import i18n from './src/i18n/index.ts';
 import { formatTime } from './src/i18n/format.ts';
 
@@ -67,6 +68,7 @@ function App() {
           <LanguageSwitcher />
         </div>
       </div>
+      {view !== 'login' && <NewMessageCard token={token} />}
       {view === 'login' && <Login onLogin={handleLogin} />}
       {view === 'list' && (
         <IncidentList

--- a/ui/src/components/NewMessageCard.tsx
+++ b/ui/src/components/NewMessageCard.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  token: string;
+  operationId?: string;
+}
+
+interface OrgUnit {
+  org_unit_id: string;
+  scope: string;
+  unit_name: string;
+}
+
+interface Message {
+  message_id: string;
+  content: string;
+}
+
+export default function NewMessageCard({ token, operationId }: Props) {
+  const opId = operationId || '00000000-0000-0000-0000-000000000000';
+  const [units, setUnits] = useState<OrgUnit[]>([]);
+  const [recipient, setRecipient] = useState('');
+  const [content, setContent] = useState('');
+  const [drafts, setDrafts] = useState<Message[]>([]);
+
+  useEffect(() => {
+    fetch(`/operations/${opId}/org-units`)
+      .then((res) => res.json())
+      .then(setUnits)
+      .catch(() => setUnits([]));
+  }, [opId]);
+
+  const headers: any = token ? { Authorization: `Bearer ${token}` } : {};
+
+  const saveDraft = () => {
+    const [scope, unit] = recipient.split(':');
+    fetch(`/operations/${opId}/messages`, {
+      method: 'POST',
+      headers: { ...headers, 'content-type': 'application/json' },
+      body: JSON.stringify({ recipientScope: scope, recipientUnit: unit, content }),
+    })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((msg) => {
+        setDrafts((d) => [...d, msg]);
+        setContent('');
+      })
+      .catch(() => {});
+  };
+
+  const submit = (id: string) => {
+    fetch(`/operations/${opId}/messages/${id}/submit`, {
+      method: 'PUT',
+      headers,
+    })
+      .then(() => setDrafts((d) => d.filter((m) => m.message_id !== id)))
+      .catch(() => {});
+  };
+
+  return (
+    <div className="border p-2 rounded space-y-2">
+      <h2 className="font-semibold">New Message</h2>
+      <select
+        className="border p-1 w-full"
+        value={recipient}
+        onChange={(e) => setRecipient(e.target.value)}
+      >
+        <option value="">Select recipient</option>
+        {units.map((u) => (
+          <option
+            key={u.org_unit_id}
+            value={`${u.scope}:${u.unit_name}`}
+          >
+            {u.unit_name}
+          </option>
+        ))}
+      </select>
+      <textarea
+        className="border p-1 w-full"
+        rows={3}
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+      <div className="flex gap-2">
+        <button
+          className="bg-gray-200 px-2 rounded"
+          onClick={saveDraft}
+          disabled={!recipient || !content}
+        >
+          Save Draft
+        </button>
+      </div>
+      {drafts.length > 0 && (
+        <div className="pt-2 border-t">
+          <h3 className="font-medium text-sm">My Drafts</h3>
+          {drafts.map((d) => (
+            <div key={d.message_id} className="flex justify-between py-1">
+              <span className="text-sm">{d.content}</span>
+              <button
+                className="text-blue-600 text-sm"
+                onClick={() => submit(d.message_id)}
+              >
+                Submit
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce messages and org_units tables for operations
- support drafting and submitting messages with XMPP and warlog hooks
- add simple New Message card to UI

## Testing
- `pnpm -r test` *(fails: Cannot find module '@tactix/lib-db')*

------
https://chatgpt.com/codex/tasks/task_e_68a0b8691a648323811ec5d148a5a9e1