### PR TITLE
docs: highlight warlog service and project valuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ This repository contains a containerized skeleton for the core services:
 - **incident-svc** – event‑sourced incident tracking
 - **tak-ingest-svc** – Cursor-on-Target ingest pipeline
 - **realtime-svc** – WebSocket gateway
+- **warlog-svc** – operational war log service
+- **eng-svc** – engineering chat (ENGNET)
 - **ui** – placeholder web UI
+
+## Development Value
+
+As of August 2025 the codebase contains roughly 3.3 KLOC of TypeScript and JavaScript. Applying the COCOMO model yields an estimated 8.5 person-months of effort, translating to approximately CAD $100k–$150k in development value. Factoring in its federated auth, realtime pipeline, and TAK ingest capabilities, a capability-equivalent rebuild would likely require CAD $200k–$450k.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- mention warlog and eng chat services in README core services list
- document estimated development value and rebuild cost for current codebase

## Testing
- `pnpm -r test` *(fails: Cannot find module '@tactix/lib-db' and 'pg-mem')*

------
https://chatgpt.com/codex/tasks/task_e_68a0c001155c832382b5954eec0448e6