### PR TITLE
feat(rbac): add RBAC doc and stub service

### DIFF
--- a/docs/RBAC.md
+++ b/docs/RBAC.md
@@ -1,0 +1,54 @@
+# RBAC in TACTIX (App-Managed)
+**Auth:** LDAP/AD for identity only.  
+**Authorization:** Managed inside TACTIX per operation (RBAC).  
+**Default READ:** Users in the operation’s AD group(s) get read by default.  
+**IMO managers:** Users in `${operation.code}_IMO` can assign roles/positions in-app.  
+**Future:** Fine-grained action permissions (ABAC/classification later).
+
+## Roles (current)
+- VIEWER — read-only for an operation.
+- EDITOR — create/update incidents & warlog for an operation.
+- IMO — can ASSIGN roles/positions (operation-level manager).
+- ADMIN — operation admin (superset; can ASSIGN + future admin actions).
+
+## Sources of authority
+1) **LDAP groups → default READ**  
+   If user is in any AD group matching `<operationCode>_(READ|VIEW|ALL)`, they are a VIEWER by default.
+2) **App database → grants/assignments**  
+   - `operation_role_grants` (role per user per operation)  
+   - `assignments` (optional, for position + alt name)
+
+## Effective permission evaluation (v1)
+- Start with AD-derived roles (VIEWER if matched).
+- Overlay DB grants (highest wins): ADMIN > IMO > EDITOR > VIEWER.
+- Map to actions:
+  - READ: VIEWER|EDITOR|IMO|ADMIN
+  - WRITE: EDITOR|IMO|ADMIN
+  - ASSIGN: IMO|ADMIN
+  - ADMIN: ADMIN
+
+## Endpoints (planned)
+- `GET /operations/:opId/permissions` — view grants (restricted view for non-ASSIGN).  
+- `POST /operations/:opId/permissions` — upsert a user’s role (ASSIGN).  
+- `DELETE /operations/:opId/permissions/:grantId` — revoke (ASSIGN).  
+- `GET /me/effective-permissions?operationCode=...` — caller’s effective roles.
+
+## Data model (planned tables)
+- `operation_role_grants(operation_id, user_upn, role, alt_name, ...)`  
+- `assignments(operation_id, user_upn, position_id, alt_display_name, active, ...)`
+
+## UI (Permissions Card — planned)
+- Visible to VIEWER+; management controls only for IMO/ADMIN.
+- Table of grants + “Add assignment” form.
+- i18n keys under `perm.*` and `roles.*` (EN/FR).
+
+## Examples (YAML sketch; not enforced yet)
+permissions:
+  incident.create: [EDITOR, IMO, ADMIN]
+  incident.status.approve: [IMO, ADMIN]
+  rbac.assign: [IMO, ADMIN]
+
+## Security notes
+- LDAP is for login only; do not mutate LDAP from TACTIX.
+- Keep ENGNET separate from ops RBAC.
+- Log authorization decisions for audit.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "services/*"
+  - "services/rbac"
   - "packages/*"
   - "ui"
   - "gateway"

--- a/services/rbac/package.json
+++ b/services/rbac/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tactix/rbac",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "tsx": "^4.16.2",
+    "vitest": "^1.6.0",
+    "@types/node": "^20.12.12"
+  }
+}

--- a/services/rbac/src/index.test.ts
+++ b/services/rbac/src/index.test.ts
@@ -1,0 +1,23 @@
+import { computeEffective, can } from './index';
+
+test('AD-derived VIEWER via suffix match', () => {
+  const eff = computeEffective({
+    upn: 'u@example.com',
+    adGroups: ['OPX_READ'],
+    operationCode: 'OPX',
+    dbGrantRole: null
+  });
+  expect(eff.roles.includes('VIEWER')).toBe(true);
+});
+
+test('DB grant overrides to EDITOR', () => {
+  const eff = computeEffective({
+    upn: 'u@example.com',
+    adGroups: [],
+    operationCode: 'OPX',
+    dbGrantRole: 'EDITOR'
+  });
+  expect(eff.roles.includes('EDITOR')).toBe(true);
+  expect(can(eff.roles, 'WRITE')).toBe(true);
+  expect(can(eff.roles, 'ASSIGN')).toBe(false);
+});

--- a/services/rbac/src/index.ts
+++ b/services/rbac/src/index.ts
@@ -1,0 +1,69 @@
+/**
+ * RBAC stub for TACTIX — no external calls here.
+ * Wire this into services on Ubuntu when implementing real checks.
+ */
+export type Role = 'VIEWER'|'EDITOR'|'IMO'|'ADMIN';
+export type Action = 'READ'|'WRITE'|'ASSIGN'|'ADMIN';
+
+export interface EffectiveInput {
+  upn: string;
+  adGroups: string[];
+  operationCode: string;
+  readSuffixes?: string[]; // defaults: ['READ','VIEW','ALL']
+  dbGrantRole?: Role | null; // pass a DB-derived role if known
+}
+
+export interface EffectiveResult {
+  roles: Role[];          // deduped; may include multiple
+  highest: Role;          // ADMIN > IMO > EDITOR > VIEWER
+}
+
+const ORDER: Role[] = ['VIEWER','EDITOR','IMO','ADMIN'];
+const ACTION_MAP: Record<Action, Role[]> = {
+  READ:   ['VIEWER','EDITOR','IMO','ADMIN'],
+  WRITE:  ['EDITOR','IMO','ADMIN'],
+  ASSIGN: ['IMO','ADMIN'],
+  ADMIN:  ['ADMIN']
+};
+
+export function computeEffective(input: EffectiveInput): EffectiveResult {
+  const readSuffixes = (input.readSuffixes && input.readSuffixes.length)
+    ? input.readSuffixes : ['READ','VIEW','ALL'];
+
+  const roles = new Set<Role>();
+
+  // AD-derived VIEWER
+  const prefix = `${input.operationCode}_`;
+  const hasReadGroup = input.adGroups.some(g => {
+    if (!g.startsWith(prefix)) return false;
+    const suffix = g.slice(prefix.length);
+    return readSuffixes.includes(suffix);
+  });
+  if (hasReadGroup) roles.add('VIEWER');
+
+  // DB grant overlay (if provided)
+  if (input.dbGrantRole) roles.add(input.dbGrantRole);
+
+  // Highest role calculation
+  let highest: Role = 'VIEWER';
+  for (const r of roles) {
+    if (ORDER.indexOf(r) > ORDER.indexOf(highest)) highest = r;
+  }
+  if (roles.size === 0) highest = 'VIEWER'; // default to VIEWER only if AD grants; otherwise no role—up to caller
+
+  return { roles: [...roles], highest };
+}
+
+export function can(roles: Role[] | Set<Role>, action: Action): boolean {
+  const have = new Set<Role>(roles as Role[]);
+  return ACTION_MAP[action].some(r => have.has(r));
+}
+
+// Placeholder assign & check — to be replaced with real DB-backed logic.
+export async function assignRole(_userUpn: string, _role: Role, _operationId: string, _byUpn: string): Promise<void> {
+  console.log('[RBAC] TODO assignRole', { _userUpn, _role, _operationId, _byUpn });
+}
+
+export async function checkPermission(eff: EffectiveResult, action: Action): Promise<boolean> {
+  return can(eff.roles, action);
+}

--- a/services/rbac/tsconfig.json
+++ b/services/rbac/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- document app-managed RBAC flow and future endpoints
- scaffold `@tactix/rbac` package for computing effective roles
- add workspace entry for new service

## Testing
- `pnpm -r install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm -r build` *(fails: TS errors in incident-svc)*
- `pnpm --filter @tactix/rbac build`
- `pnpm --filter @tactix/rbac test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a102f446b083239d89b8a7c9974d8a