### PR TITLE
feat(incident): add event-sourced incident service

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "services/*"
+  - "services/incident"
   - "services/rbac"
   - "packages/*"
   - "ui"

--- a/services/incident/.env.example
+++ b/services/incident/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables for incident service
+PORT=3000
+DATABASE_URL=postgres://user:pass@localhost:5432/tactix

--- a/services/incident/jest.config.js
+++ b/services/incident/jest.config.js
@@ -1,0 +1,8 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};

--- a/services/incident/migrations/001_create_incidents_events.sql
+++ b/services/incident/migrations/001_create_incidents_events.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS incidents_events (
+  id UUID PRIMARY KEY,
+  incident_id UUID NOT NULL,
+  type TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS incidents_events_incident_id_idx
+  ON incidents_events (incident_id, timestamp);

--- a/services/incident/package.json
+++ b/services/incident/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "incident",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "zod": "^3.23.8",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.30",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "typescript": "^5.4.5",
+    "supertest": "^6.3.3",
+    "@types/supertest": "^2.0.12"
+  }
+}

--- a/services/incident/src/api.ts
+++ b/services/incident/src/api.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import { z } from 'zod';
+import { randomUUID } from 'crypto';
+import { EventStore } from './infrastructure/EventStore.js';
+import { Incident } from './domain/Incident.js';
+
+export function createApp(store: EventStore) {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', (_req: any, res: any) => {
+    res.json({ ok: true });
+  });
+
+  app.post('/incidents', async (req: any, res: any, next: any) => {
+    try {
+      const schema = z.object({ title: z.string(), description: z.string(), org: z.string() });
+      const { title, description, org } = schema.parse(req.body);
+      const id = randomUUID();
+      const [incident, event] = Incident.create({ id, title, description, org });
+      await store.append(id, event);
+      res.status(201).json(incident.toJSON());
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.get('/incidents/:id', async (req: any, res: any, next: any) => {
+    try {
+      const id = req.params.id;
+      const events = await store.load(id);
+      if (events.length === 0) {
+        res.sendStatus(404);
+        return;
+      }
+      const incident = Incident.from(id, events);
+      res.json(incident.toJSON());
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/incidents/:id/messages', async (req: any, res: any, next: any) => {
+    try {
+      const schema = z.object({ message: z.string() });
+      const { message } = schema.parse(req.body);
+      const id = req.params.id;
+      const events = await store.load(id);
+      if (events.length === 0) {
+        res.sendStatus(404);
+        return;
+      }
+      const incident = Incident.from(id, events);
+      const event = incident.addMessage(message);
+      await store.append(id, event);
+      res.json(incident.toJSON());
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  app.post('/incidents/:id/submit', async (req: any, res: any, next: any) => {
+    try {
+      const id = req.params.id;
+      const events = await store.load(id);
+      if (events.length === 0) {
+        res.sendStatus(404);
+        return;
+      }
+      const incident = Incident.from(id, events);
+      const event = incident.submit();
+      await store.append(id, event);
+      res.json(incident.toJSON());
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return app;
+}

--- a/services/incident/src/domain/Incident.ts
+++ b/services/incident/src/domain/Incident.ts
@@ -1,0 +1,91 @@
+import { IncidentEvent, IncidentCreated, MessageAdded, IncidentSubmitted, IncidentUpdated } from './events.js';
+
+export type IncidentStatus = 'Draft' | 'Submitted' | 'Closed';
+
+export interface IncidentState {
+  id: string;
+  title: string;
+  description: string;
+  status: IncidentStatus;
+  org: string;
+  messages: string[];
+}
+
+export class Incident {
+  private state: IncidentState;
+
+  private constructor(state: IncidentState) {
+    this.state = state;
+  }
+
+  static create(params: { id: string; title: string; description: string; org: string }): [Incident, IncidentEvent] {
+    const event: IncidentCreated = {
+      type: 'IncidentCreated',
+      data: { title: params.title, description: params.description, org: params.org }
+    };
+    const incident = new Incident({
+      id: params.id,
+      title: '',
+      description: '',
+      status: 'Draft',
+      org: params.org,
+      messages: []
+    });
+    incident.apply(event);
+    return [incident, event];
+  }
+
+  static from(id: string, events: IncidentEvent[]): Incident {
+    const incident = new Incident({ id, title: '', description: '', status: 'Draft', org: '', messages: [] });
+    for (const e of events) {
+      incident.apply(e);
+    }
+    return incident;
+  }
+
+  addMessage(message: string): IncidentEvent {
+    const event: MessageAdded = { type: 'MessageAdded', data: { message } };
+    this.apply(event);
+    return event;
+  }
+
+  submit(): IncidentEvent {
+    if (this.state.status !== 'Draft') {
+      throw new Error('Only draft incidents can be submitted');
+    }
+    const event: IncidentSubmitted = { type: 'IncidentSubmitted', data: {} };
+    this.apply(event);
+    return event;
+  }
+
+  update(fields: { title?: string; description?: string }): IncidentEvent {
+    const event: IncidentUpdated = { type: 'IncidentUpdated', data: fields };
+    this.apply(event);
+    return event;
+  }
+
+  apply(event: IncidentEvent): void {
+    switch (event.type) {
+      case 'IncidentCreated':
+        this.state.title = event.data.title;
+        this.state.description = event.data.description;
+        this.state.org = event.data.org;
+        this.state.status = 'Draft';
+        break;
+      case 'IncidentUpdated':
+        if (event.data.title !== undefined) this.state.title = event.data.title;
+        if (event.data.description !== undefined) this.state.description = event.data.description;
+        break;
+      case 'IncidentSubmitted':
+        this.state.status = 'Submitted';
+        break;
+      case 'MessageAdded':
+        this.state.messages.push(event.data.message);
+        break;
+    }
+  }
+
+  toJSON(): IncidentState {
+    return { ...this.state };
+  }
+}

--- a/services/incident/src/domain/events.ts
+++ b/services/incident/src/domain/events.ts
@@ -1,0 +1,25 @@
+export type IncidentCreated = {
+  type: 'IncidentCreated';
+  data: { title: string; description: string; org: string };
+};
+
+export type IncidentUpdated = {
+  type: 'IncidentUpdated';
+  data: { title?: string; description?: string };
+};
+
+export type IncidentSubmitted = {
+  type: 'IncidentSubmitted';
+  data: {};
+};
+
+export type MessageAdded = {
+  type: 'MessageAdded';
+  data: { message: string };
+};
+
+export type IncidentEvent =
+  | IncidentCreated
+  | IncidentUpdated
+  | IncidentSubmitted
+  | MessageAdded;

--- a/services/incident/src/index.ts
+++ b/services/incident/src/index.ts
@@ -1,0 +1,12 @@
+import { Pool } from 'pg';
+import { createApp } from './api.js';
+import { PgEventStore } from './infrastructure/EventStore.js';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const store = new PgEventStore(pool);
+const app = createApp(store);
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+app.listen(port, () => {
+  console.log(`incident service listening on ${port}`);
+});

--- a/services/incident/src/infrastructure/EventStore.ts
+++ b/services/incident/src/infrastructure/EventStore.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from 'crypto';
+import { IncidentEvent } from '../domain/events.js';
+
+export interface EventStore {
+  append(incidentId: string, event: IncidentEvent): Promise<void>;
+  load(incidentId: string): Promise<IncidentEvent[]>;
+}
+
+export class InMemoryEventStore implements EventStore {
+  private events = new Map<string, IncidentEvent[]>();
+
+  async append(incidentId: string, event: IncidentEvent): Promise<void> {
+    const arr = this.events.get(incidentId) || [];
+    arr.push(event);
+    this.events.set(incidentId, arr);
+  }
+
+  async load(incidentId: string): Promise<IncidentEvent[]> {
+    return this.events.get(incidentId) ?? [];
+  }
+}
+
+export class PgEventStore implements EventStore {
+  constructor(private pool: any) {}
+
+  async append(incidentId: string, event: IncidentEvent): Promise<void> {
+    await this.pool.query(
+      'INSERT INTO incidents_events (id, incident_id, type, payload, timestamp) VALUES ($1,$2,$3,$4,$5)',
+      [randomUUID(), incidentId, event.type, event.data, new Date()]
+    );
+  }
+
+  async load(incidentId: string): Promise<IncidentEvent[]> {
+    const res = await this.pool.query(
+      'SELECT type, payload FROM incidents_events WHERE incident_id=$1 ORDER BY timestamp ASC',
+      [incidentId]
+    );
+    return res.rows.map((r: any) => ({ type: r.type, data: r.payload }));
+  }
+}

--- a/services/incident/src/typings.d.ts
+++ b/services/incident/src/typings.d.ts
@@ -1,0 +1,5 @@
+declare module 'express';
+declare module 'zod';
+declare module 'pg';
+declare module 'crypto';
+declare const process: any;

--- a/services/incident/tests/incident.test.ts
+++ b/services/incident/tests/incident.test.ts
@@ -1,0 +1,37 @@
+import request from 'supertest';
+import { createApp } from '../src/api.js';
+import { InMemoryEventStore } from '../src/infrastructure/EventStore.js';
+
+describe('incident service', () => {
+  const store = new InMemoryEventStore();
+  const app = createApp(store);
+
+  it('creates a draft incident', async () => {
+    const res = await request(app)
+      .post('/incidents')
+      .send({ title: 'T', description: 'D', org: 'unit' })
+      .expect(201);
+    expect(res.body.status).toBe('Draft');
+    expect(res.body.title).toBe('T');
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('adds messages and submits', async () => {
+    const createRes = await request(app)
+      .post('/incidents')
+      .send({ title: 'X', description: 'Y', org: 'unit' })
+      .expect(201);
+    const id = createRes.body.id;
+
+    const msgRes = await request(app)
+      .post(`/incidents/${id}/messages`)
+      .send({ message: 'hello' })
+      .expect(200);
+    expect(msgRes.body.messages).toEqual(['hello']);
+
+    const submitRes = await request(app)
+      .post(`/incidents/${id}/submit`)
+      .expect(200);
+    expect(submitRes.body.status).toBe('Submitted');
+  });
+});

--- a/services/incident/tsconfig.json
+++ b/services/incident/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add new incident service with event-sourcing core and REST API
- store events in Postgres table `incidents_events`
- provide Jest tests for draft, messaging, and submit flows

## Testing
- `pnpm -r build` *(fails: Property 'user' does not exist on type 'IncomingMessage' in existing incident-svc)*
- `pnpm --filter incident test` *(fails: jest not found due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a1079e2eec8323a5d43b38c96d0659