### PR TITLE
feat(playbook-svc): incident playbooks and run

### DIFF
--- a/docs/playbook-svc.md
+++ b/docs/playbook-svc.md
@@ -1,10 +1,12 @@
 # playbook-svc
 
-Provides simple filesystem-backed playbook definitions and trigger endpoint.
+Stores incident-scoped playbooks and allows manual runs that emit in-app notifications.
 
 ## Routes
-- `GET /playbooks` — list playbooks (id, name, summary)
-- `POST /playbooks/:id/trigger` — body `{ incidentId, operationCode?, message?, severity? }`
+- `GET /incidents/:incidentId/playbooks` — list playbooks for an incident
+- `POST /incidents/:incidentId/playbooks` — create `{ name, json }`
+- `GET /playbooks/:id` — fetch playbook JSON
+- `POST /playbooks/:id/run` — body `{ incidentId, message?, severity? }`
 
 ## Env Vars
 - `PORT` (default 3005)
@@ -12,5 +14,5 @@ Provides simple filesystem-backed playbook definitions and trigger endpoint.
 - `ORG_CODE` organization code
 
 ## Notes
-- Reads definitions from `/playbooks/*.json` mounted read-only.
-- Triggers emit `NOTIFY tactix_events` with `type: PLAYBOOK_NOTIFY` for realtime fan-out.
+- Playbooks are stored in Postgres (`playbooks`, `playbook_runs` tables).
+- Runs emit `NOTIFY tactix_events` with `type: PLAYBOOK_NOTIFY` for realtime fan-out.

--- a/services/playbook-svc/migrate.js
+++ b/services/playbook-svc/migrate.js
@@ -1,0 +1,34 @@
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+import pkg from 'pg';
+
+const { Client } = pkg;
+
+async function main() {
+  const direction = process.argv[2];
+  if (!direction || !['up', 'down'].includes(direction)) {
+    console.error('Usage: pnpm migrate up|down');
+    process.exit(1);
+  }
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const migrationsDir = path.join(__dirname, 'migrations', direction);
+  const files = fs.existsSync(migrationsDir)
+    ? fs.readdirSync(migrationsDir).sort()
+    : [];
+  const client = new Client({ connectionString: process.env.PGURL });
+  await client.connect();
+  try {
+    for (const file of files) {
+      const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+      await client.query(sql);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/services/playbook-svc/migrations/down/001_drop_playbooks.sql
+++ b/services/playbook-svc/migrations/down/001_drop_playbooks.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS playbooks;

--- a/services/playbook-svc/migrations/down/002_drop_playbook_runs.sql
+++ b/services/playbook-svc/migrations/down/002_drop_playbook_runs.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS playbook_runs;

--- a/services/playbook-svc/migrations/down/003_drop_incident_tasks.sql
+++ b/services/playbook-svc/migrations/down/003_drop_incident_tasks.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS incident_tasks;

--- a/services/playbook-svc/migrations/up/001_create_playbooks.sql
+++ b/services/playbook-svc/migrations/up/001_create_playbooks.sql
@@ -1,0 +1,10 @@
+CREATE TABLE playbooks (
+  playbook_id UUID PRIMARY KEY,
+  incident_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  json JSONB NOT NULL,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (incident_id, name)
+);

--- a/services/playbook-svc/migrations/up/002_create_playbook_runs.sql
+++ b/services/playbook-svc/migrations/up/002_create_playbook_runs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE playbook_runs (
+  run_id UUID PRIMARY KEY,
+  playbook_id UUID NOT NULL REFERENCES playbooks(playbook_id) ON DELETE CASCADE,
+  incident_id UUID NOT NULL,
+  requested_by TEXT NOT NULL,
+  approved_by TEXT,
+  status TEXT CHECK (status IN ('suggested','approved','executed','failed')) NOT NULL,
+  overrides JSONB,
+  result JSONB,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  executed_at TIMESTAMPTZ
+);

--- a/services/playbook-svc/migrations/up/003_create_incident_tasks.sql
+++ b/services/playbook-svc/migrations/up/003_create_incident_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE incident_tasks (
+  task_id UUID PRIMARY KEY,
+  incident_id UUID NOT NULL,
+  role TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status TEXT CHECK (status IN ('open','done','cancelled')) DEFAULT 'open',
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/services/playbook-svc/package.json
+++ b/services/playbook-svc/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
-    "test": "echo 'no tests'"
+    "test": "echo 'no tests'",
+    "migrate": "node migrate.js"
   },
   "dependencies": {
     "express": "^4.19.2",

--- a/services/playbook-svc/src/auth.ts
+++ b/services/playbook-svc/src/auth.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export interface AuthPayload {
+  sub: string;
+  roles: string[];
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthPayload;
+}
+
+export function requireAuth(
+  req: AuthenticatedRequest,
+  res: Response,
+  next: NextFunction
+) {
+  const user = req.header('X-User');
+  if (!user) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const roles = (req.header('X-Roles') || '').split(',').filter(Boolean);
+  req.user = { sub: user, roles };
+  next();
+}

--- a/services/playbook-svc/src/rbac.ts
+++ b/services/playbook-svc/src/rbac.ts
@@ -1,0 +1,7 @@
+export function canEditPlaybooks(roles: string[]): boolean {
+  return roles.some((r) => ['IMO', 'DO', 'SDO', 'G3 OPS', 'ADMIN'].includes(r));
+}
+
+export function canRunPlaybooks(roles: string[]): boolean {
+  return roles.includes('DO');
+}


### PR DESCRIPTION
## Summary
- store playbooks per incident in Postgres
- DO-only run endpoint emits PLAYBOOK_NOTIFY and records run
- add migrations for playbooks, runs, and tasks

## Testing
- `pnpm --filter @tactix/playbook-svc test`
- `pnpm --filter @tactix/playbook-svc build`
- `node services/playbook-svc/migrate.js up` *(fails: ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_68a1363d690883238b6fd498aeacffe7