### PR TITLE
feat(ui+svc): add incident workspace endpoints and UI

### DIFF
--- a/services/incident-svc/migrations/down/015_drop_incident_chat_messages.sql
+++ b/services/incident-svc/migrations/down/015_drop_incident_chat_messages.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS incident_chat_messages;

--- a/services/incident-svc/migrations/down/016_revert_incident_tasks.sql
+++ b/services/incident-svc/migrations/down/016_revert_incident_tasks.sql
@@ -1,0 +1,13 @@
+ALTER TABLE IF EXISTS incident_tasks
+  DROP COLUMN IF EXISTS assignee_upn,
+  DROP COLUMN IF EXISTS title,
+  DROP COLUMN IF EXISTS created_by,
+  DROP COLUMN IF EXISTS updated_at;
+ALTER TABLE IF EXISTS incident_tasks
+  DROP CONSTRAINT IF EXISTS incident_tasks_status_check;
+ALTER TABLE IF EXISTS incident_tasks
+  ADD CONSTRAINT incident_tasks_status_check
+    CHECK (status IN ('open','done','cancelled'));
+ALTER TABLE IF EXISTS incident_tasks
+  DROP CONSTRAINT IF EXISTS incident_tasks_incident_id_fkey;
+DROP INDEX IF EXISTS ix_it_incident_status;

--- a/services/incident-svc/migrations/up/015_create_incident_chat_messages.sql
+++ b/services/incident-svc/migrations/up/015_create_incident_chat_messages.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS incident_chat_messages (
+  msg_id UUID PRIMARY KEY,
+  incident_id UUID NOT NULL REFERENCES incidents(incident_id) ON DELETE CASCADE,
+  author_upn TEXT NOT NULL,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS ix_icm_incident_created
+  ON incident_chat_messages(incident_id, created_at DESC);

--- a/services/incident-svc/migrations/up/016_alter_incident_tasks.sql
+++ b/services/incident-svc/migrations/up/016_alter_incident_tasks.sql
@@ -1,0 +1,26 @@
+-- Add fields to incident_tasks if table exists
+ALTER TABLE IF EXISTS incident_tasks
+  ADD COLUMN IF NOT EXISTS assignee_upn TEXT,
+  ADD COLUMN IF NOT EXISTS title TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'open',
+  ADD COLUMN IF NOT EXISTS created_by TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Update status constraint
+ALTER TABLE IF EXISTS incident_tasks
+  DROP CONSTRAINT IF EXISTS incident_tasks_status_check;
+ALTER TABLE IF EXISTS incident_tasks
+  ADD CONSTRAINT incident_tasks_status_check
+    CHECK (status IN ('open','in_progress','done','cancelled'));
+
+-- Add foreign key to incidents
+ALTER TABLE IF EXISTS incident_tasks
+  DROP CONSTRAINT IF EXISTS incident_tasks_incident_id_fkey;
+ALTER TABLE IF EXISTS incident_tasks
+  ADD CONSTRAINT incident_tasks_incident_id_fkey
+    FOREIGN KEY (incident_id) REFERENCES incidents(incident_id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS ix_it_incident_status
+  ON incident_tasks(incident_id, status, updated_at DESC);

--- a/services/incident-svc/package.json
+++ b/services/incident-svc/package.json
@@ -14,7 +14,8 @@
     "@tactix/auth": "workspace:*",
     "@tactix/types": "workspace:*",
     "express": "^4.18.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/services/incident-svc/src/index.ts
+++ b/services/incident-svc/src/index.ts
@@ -6,6 +6,9 @@ import { Client, createClient } from '@tactix/lib-db';
 import { requireAuth, requireRole, AuthenticatedRequest } from '@tactix/auth';
 import { effective } from './rbac/effective';
 import { draftMessageHandler, submitMessageHandler } from './routes/incidents/messages.js';
+import { getChatHandler, postChatHandler } from './routes/incidents/chat.js';
+import { getTasksHandler, postTaskHandler, patchTaskHandler } from './routes/incidents/tasks.js';
+import { getActivityHandler } from './routes/incidents/activity.js';
 
 declare const process: any;
 declare const Buffer: any;
@@ -408,6 +411,53 @@ export function createServer() {
       const incidentId = Number(submitMatch[1]);
       return requireAuth(req as AuthenticatedRequest, res, () =>
         submitMessageHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
+      );
+    }
+
+    const chatMatch = url.pathname.match(/^\/incidents\/(\d+)\/chat$/);
+    if (chatMatch && dbClient) {
+      const incidentId = Number(chatMatch[1]);
+      if (req.method === 'GET') {
+        return requireAuth(req as AuthenticatedRequest, res, () =>
+          getChatHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
+        );
+      }
+      if (req.method === 'POST') {
+        return requireAuth(req as AuthenticatedRequest, res, () =>
+          postChatHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
+        );
+      }
+    }
+
+    const tasksMatch = url.pathname.match(/^\/incidents\/(\d+)\/tasks$/);
+    if (tasksMatch && dbClient) {
+      const incidentId = Number(tasksMatch[1]);
+      if (req.method === 'GET') {
+        return requireAuth(req as AuthenticatedRequest, res, () =>
+          getTasksHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
+        );
+      }
+      if (req.method === 'POST') {
+        return requireAuth(req as AuthenticatedRequest, res, () =>
+          postTaskHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
+        );
+      }
+    }
+
+    const taskPatchMatch = url.pathname.match(/^\/incidents\/(\d+)\/tasks\/([^/]+)$/);
+    if (taskPatchMatch && req.method === 'PATCH' && dbClient) {
+      const incidentId = Number(taskPatchMatch[1]);
+      const taskId = taskPatchMatch[2];
+      return requireAuth(req as AuthenticatedRequest, res, () =>
+        patchTaskHandler(req as AuthenticatedRequest, res, incidentId, taskId, dbClient!)
+      );
+    }
+
+    const activityMatch = url.pathname.match(/^\/incidents\/(\d+)\/activity$/);
+    if (activityMatch && req.method === 'GET' && dbClient) {
+      const incidentId = Number(activityMatch[1]);
+      return requireAuth(req as AuthenticatedRequest, res, () =>
+        getActivityHandler(req as AuthenticatedRequest, res, incidentId, dbClient!)
       );
     }
 

--- a/services/incident-svc/src/routes/incidents/activity.ts
+++ b/services/incident-svc/src/routes/incidents/activity.ts
@@ -1,0 +1,59 @@
+import http from 'node:http';
+
+export type Client = any;
+export type AuthenticatedRequest = any;
+
+function json(res: http.ServerResponse, code: number, body: any) {
+  res.statusCode = code;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+export async function getActivityHandler(
+  _req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  client: Client
+) {
+  const url = new URL(_req.url || '', 'http://localhost');
+  const limit = Math.min(Number(url.searchParams.get('limit')) || 100, 500);
+  const chat = await client.query(
+    'SELECT msg_id, author_upn, text, created_at FROM incident_chat_messages WHERE incident_id=$1',
+    [incidentId]
+  );
+  const warlog = await client.query(
+    'SELECT message_id, author_upn, content, created_at FROM incident_messages WHERE incident_id=$1',
+    [incidentId]
+  );
+  const tasks = await client.query(
+    'SELECT task_id, title, status, updated_at FROM incident_tasks WHERE incident_id=$1',
+    [incidentId]
+  );
+  const items: any[] = [
+    ...chat.rows.map((r: any) => ({
+      kind: 'chat',
+      id: r.msg_id,
+      authorUpn: r.author_upn,
+      text: r.text,
+      createdAt: r.created_at,
+    })),
+    ...warlog.rows.map((r: any) => ({
+      kind: 'warlog',
+      id: r.message_id,
+      authorUpn: r.author_upn,
+      text: r.content,
+      createdAt: r.created_at,
+    })),
+    ...tasks.rows.map((r: any) => ({
+      kind: 'task',
+      id: r.task_id,
+      title: r.title,
+      status: r.status,
+      createdAt: r.updated_at,
+    })),
+  ];
+  items.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+  return json(res, 200, items.slice(0, limit));
+}

--- a/services/incident-svc/src/routes/incidents/chat.ts
+++ b/services/incident-svc/src/routes/incidents/chat.ts
@@ -1,0 +1,84 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+export type Client = any;
+export type AuthenticatedRequest = any;
+
+async function readBody(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => (data += chunk));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function json(res: http.ServerResponse, code: number, body: any) {
+  res.statusCode = code;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+export async function getChatHandler(
+  req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  client: Client
+) {
+  const url = new URL(req.url || '', 'http://localhost');
+  const since = url.searchParams.get('since');
+  const limit = Math.min(Number(url.searchParams.get('limit')) || 50, 200);
+  const params: any[] = [incidentId];
+  let sql =
+    'SELECT msg_id, incident_id, author_upn, text, created_at FROM incident_chat_messages WHERE incident_id=$1';
+  if (since) {
+    params.push(new Date(since));
+    sql += ` AND created_at > $${params.length}`;
+  }
+  params.push(limit);
+  sql += ` ORDER BY created_at DESC LIMIT $${params.length}`;
+  const { rows } = await client.query(sql, params);
+  return json(res, 200, rows);
+}
+
+export async function postChatHandler(
+  req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  client: Client
+) {
+  const body = await readBody(req).catch(() => null);
+  const schema = z.object({
+    text: z.string().min(1).max(2000),
+    authorUpn: z.string().optional(),
+  });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return json(res, 400, { error: 'invalid body' });
+  const msgId = randomUUID();
+  const author = parsed.data.authorUpn || req.user?.sub || 'unknown';
+  const { rows } = await client.query(
+    'INSERT INTO incident_chat_messages (msg_id, incident_id, author_upn, text) VALUES ($1,$2,$3,$4) RETURNING *',
+    [msgId, incidentId, author, parsed.data.text]
+  );
+  const msg = rows[0];
+  try {
+    await client.query('NOTIFY tactix_events, $1', [
+      JSON.stringify({
+        type: 'INCIDENT_CHAT',
+        incidentId,
+        msgId,
+        authorUpn: author,
+        text: msg.text,
+        createdAt: msg.created_at,
+      }),
+    ]);
+  } catch {}
+  return json(res, 201, msg);
+}

--- a/services/incident-svc/src/routes/incidents/tasks.ts
+++ b/services/incident-svc/src/routes/incidents/tasks.ts
@@ -1,0 +1,152 @@
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+
+export type Client = any;
+export type AuthenticatedRequest = any;
+
+async function readBody(req: http.IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => (data += chunk));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function json(res: http.ServerResponse, code: number, body: any) {
+  res.statusCode = code;
+  res.setHeader('content-type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+export async function getTasksHandler(
+  req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  client: Client
+) {
+  const url = new URL(req.url || '', 'http://localhost');
+  const status = url.searchParams.get('status');
+  const params: any[] = [incidentId];
+  let sql =
+    'SELECT task_id, incident_id, role, assignee_upn, title, description, status, created_by, created_at, updated_at FROM incident_tasks WHERE incident_id=$1';
+  if (status) {
+    params.push(status);
+    sql += ` AND status=$${params.length}`;
+  }
+  sql += ' ORDER BY updated_at DESC';
+  const { rows } = await client.query(sql, params);
+  return json(res, 200, rows);
+}
+
+export async function postTaskHandler(
+  req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  client: Client
+) {
+  const body = await readBody(req).catch(() => null);
+  const schema = z.object({
+    role: z.string(),
+    assigneeUpn: z.string().optional(),
+    title: z.string(),
+    description: z.string(),
+  });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return json(res, 400, { error: 'invalid body' });
+  const taskId = randomUUID();
+  const createdBy = req.user?.sub || parsed.data.assigneeUpn || 'unknown';
+  const now = new Date();
+  const { rows } = await client.query(
+    'INSERT INTO incident_tasks (task_id, incident_id, role, assignee_upn, title, description, status, created_by, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9) RETURNING *',
+    [
+      taskId,
+      incidentId,
+      parsed.data.role,
+      parsed.data.assigneeUpn || null,
+      parsed.data.title,
+      parsed.data.description,
+      'open',
+      createdBy,
+      now,
+    ]
+  );
+  const task = rows[0];
+  try {
+    await client.query('NOTIFY tactix_events, $1', [
+      JSON.stringify({
+        type: 'INCIDENT_TASK_CREATED',
+        incidentId,
+        taskId,
+        title: task.title,
+        status: task.status,
+      }),
+    ]);
+  } catch {}
+  return json(res, 201, task);
+}
+
+export async function patchTaskHandler(
+  req: AuthenticatedRequest,
+  res: http.ServerResponse,
+  incidentId: number,
+  taskId: string,
+  client: Client
+) {
+  const body = await readBody(req).catch(() => null);
+  const schema = z.object({
+    status: z.enum(['open', 'in_progress', 'done', 'cancelled']).optional(),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    assigneeUpn: z.string().optional(),
+  });
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return json(res, 400, { error: 'invalid body' });
+  const fields: string[] = [];
+  const params: any[] = [];
+  if (parsed.data.status) {
+    fields.push(`status=$${params.length + 1}`);
+    params.push(parsed.data.status);
+  }
+  if (parsed.data.title) {
+    fields.push(`title=$${params.length + 1}`);
+    params.push(parsed.data.title);
+  }
+  if (parsed.data.description) {
+    fields.push(`description=$${params.length + 1}`);
+    params.push(parsed.data.description);
+  }
+  if (parsed.data.assigneeUpn !== undefined) {
+    fields.push(`assignee_upn=$${params.length + 1}`);
+    params.push(parsed.data.assigneeUpn);
+  }
+  if (!fields.length) return json(res, 200, {});
+  fields.push(`updated_at=$${params.length + 1}`);
+  params.push(new Date());
+  params.push(incidentId);
+  params.push(taskId);
+  const sql = `UPDATE incident_tasks SET ${fields.join(', ')} WHERE incident_id=$${
+    params.length - 1
+  } AND task_id=$${params.length} RETURNING *`;
+  const { rows } = await client.query(sql, params);
+  if (rows.length === 0) return json(res, 404, {});
+  const task = rows[0];
+  try {
+    await client.query('NOTIFY tactix_events, $1', [
+      JSON.stringify({
+        type: 'INCIDENT_TASK_UPDATED',
+        incidentId,
+        taskId,
+        status: task.status,
+      }),
+    ]);
+  } catch {}
+  return json(res, 200, task);
+}

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -5,6 +5,7 @@ import LanguageSwitcher from './src/components/LanguageSwitcher.tsx';
 import NewMessageCard from './src/components/NewMessageCard.tsx';
 import EngChatPanel from './src/components/EngChatPanel.tsx';
 import GlobalBanner from './src/components/GlobalBanner.tsx';
+import IncidentWorkspacePage from './src/components/IncidentWorkspacePage.tsx';
 import { notifyStore } from './src/lib/notify.ts';
 import i18n from './src/i18n/index.ts';
 import { formatTime } from './src/i18n/format.ts';
@@ -119,6 +120,14 @@ function App() {
           token={token}
           incidentId={detailId}
           onBack={() => setView('list')}
+          onWorkspace={() => setView('workspace')}
+        />
+      )}
+      {view === 'workspace' && (
+        <IncidentWorkspacePage
+          token={token}
+          incidentId={detailId}
+          onBack={() => setView('detail')}
         />
       )}
     </div>
@@ -279,7 +288,7 @@ function IncidentList({ token, onSelect, onLogout }) {
   );
 }
 
-function IncidentDetail({ token, incidentId, onBack }) {
+function IncidentDetail({ token, incidentId, onBack, onWorkspace }) {
   const { t } = useTranslation();
   const [incident, setIncident] = useState(null);
   const [comment, setComment] = useState('');
@@ -421,9 +430,17 @@ function IncidentDetail({ token, incidentId, onBack }) {
 
   return (
     <div className="space-y-4">
-      <button className="text-blue-600 underline" onClick={onBack}>
-        &larr; Back
-      </button>
+      <div className="flex gap-2">
+        <button className="text-blue-600 underline" onClick={onBack}>
+          &larr; Back
+        </button>
+        <button
+          className="text-blue-600 underline"
+          onClick={onWorkspace}
+        >
+          {t('workspace.title')}
+        </button>
+      </div>
       {incident && (
         <div>
           <h2 className="text-lg font-semibold">{incident.title}</h2>

--- a/ui/src/components/IncidentWorkspacePage.tsx
+++ b/ui/src/components/IncidentWorkspacePage.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export default function IncidentWorkspacePage({ incidentId, token, onBack }) {
+  const { t } = useTranslation();
+  const headers: any = token
+    ? { Authorization: `Bearer ${token}`, 'content-type': 'application/json' }
+    : { 'content-type': 'application/json' };
+  const [chat, setChat] = useState<any[]>([]);
+  const [text, setText] = useState('');
+  const [tasks, setTasks] = useState<any[]>([]);
+  const [newTask, setNewTask] = useState({
+    role: 'IMO',
+    assigneeUpn: '',
+    title: '',
+    description: '',
+  });
+  const [activity, setActivity] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/incidents/${incidentId}/chat?limit=50`, { headers })
+      .then((res) => res.json())
+      .then(setChat);
+    fetch(`/incidents/${incidentId}/tasks`, { headers })
+      .then((res) => res.json())
+      .then(setTasks);
+    fetch(`/incidents/${incidentId}/activity`, { headers })
+      .then((res) => res.json())
+      .then(setActivity);
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const ws = new WebSocket(`${protocol}://${window.location.host}/rt`);
+    ws.onmessage = (evt) => {
+      let msg;
+      try {
+        msg = JSON.parse(evt.data);
+      } catch {
+        return;
+      }
+      if (msg.type === 'INCIDENT_CHAT' && msg.incidentId === incidentId) {
+        setChat((c) => [
+          ...c,
+          {
+            msg_id: msg.msgId,
+            author_upn: msg.authorUpn,
+            text: msg.text,
+            created_at: msg.createdAt,
+          },
+        ]);
+        setActivity((a) => [{ kind: 'chat', createdAt: msg.createdAt }, ...a]);
+      }
+      if (msg.type === 'INCIDENT_TASK_CREATED' && msg.incidentId === incidentId) {
+        setTasks((ts) => [
+          { task_id: msg.taskId, title: msg.title, status: msg.status },
+          ...ts,
+        ]);
+        setActivity((a) => [{ kind: 'task', createdAt: new Date().toISOString() }, ...a]);
+      }
+      if (msg.type === 'INCIDENT_TASK_UPDATED' && msg.incidentId === incidentId) {
+        setTasks((ts) =>
+          ts.map((t) => (t.task_id === msg.taskId ? { ...t, status: msg.status } : t))
+        );
+        setActivity((a) => [{ kind: 'task', createdAt: new Date().toISOString() }, ...a]);
+      }
+    };
+    return () => ws.close();
+  }, [incidentId]);
+
+  function sendChat(e: any) {
+    e.preventDefault();
+    fetch(`/incidents/${incidentId}/chat`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ text }),
+    })
+      .then((res) => res.json())
+      .then((msg) => {
+        setChat((c) => [...c, msg]);
+        setActivity((a) => [{ kind: 'chat', createdAt: msg.created_at }, ...a]);
+        setText('');
+      });
+  }
+
+  function createTask(e: any) {
+    e.preventDefault();
+    fetch(`/incidents/${incidentId}/tasks`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(newTask),
+    })
+      .then((res) => res.json())
+      .then((task) => {
+        setTasks((ts) => [task, ...ts]);
+        setActivity((a) => [{ kind: 'task', createdAt: task.updated_at }, ...a]);
+        setNewTask({ role: 'IMO', assigneeUpn: '', title: '', description: '' });
+      });
+  }
+
+  function changeStatus(id: string, status: string) {
+    fetch(`/incidents/${incidentId}/tasks/${id}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ status }),
+    })
+      .then((res) => res.json())
+      .then((task) => {
+        setTasks((ts) => ts.map((t) => (t.task_id === id ? task : t)));
+        setActivity((a) => [{ kind: 'task', createdAt: task.updated_at }, ...a]);
+      });
+  }
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onBack} className="text-blue-600 underline">
+        &larr; Back
+      </button>
+      <h2 className="text-lg font-semibold">{t('workspace.title')}</h2>
+      <div className="grid gap-4 md:grid-cols-3">
+        <div className="md:col-span-2 flex flex-col border rounded p-2 h-96">
+          <h3 className="font-semibold mb-2">{t('workspace.chat.title')}</h3>
+          <div className="flex-1 overflow-y-auto mb-2 space-y-1">
+            {chat.map((m) => (
+              <div key={m.msg_id} className="text-sm">
+                <span className="font-bold">{m.author_upn}</span>: {m.text}
+              </div>
+            ))}
+          </div>
+          <form onSubmit={sendChat} className="flex gap-2">
+            <input
+              className="border rounded p-1 flex-1"
+              value={text}
+              placeholder={t('workspace.chat.placeholder')}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <button className="bg-blue-600 text-white px-3 rounded" type="submit">
+              {t('workspace.chat.send')}
+            </button>
+          </form>
+        </div>
+        <div className="border rounded p-2 flex flex-col h-96">
+          <h3 className="font-semibold mb-2">{t('workspace.tasks.title')}</h3>
+          <div className="flex-1 overflow-y-auto space-y-1">
+            {tasks.map((tk) => (
+              <div key={tk.task_id} className="flex justify-between items-center text-sm">
+                <span>{tk.title}</span>
+                <select
+                  value={tk.status}
+                  onChange={(e) => changeStatus(tk.task_id, e.target.value)}
+                  className="border rounded p-1 text-xs"
+                >
+                  <option value="open">{t('task.status.open')}</option>
+                  <option value="in_progress">{t('task.status.in_progress')}</option>
+                  <option value="done">{t('task.status.done')}</option>
+                  <option value="cancelled">{t('task.status.cancelled')}</option>
+                </select>
+              </div>
+            ))}
+          </div>
+          <form onSubmit={createTask} className="space-y-1 pt-2 text-sm">
+            <input
+              className="border rounded p-1 w-full"
+              placeholder={t('workspace.tasks.role')}
+              value={newTask.role}
+              onChange={(e) => setNewTask({ ...newTask, role: e.target.value })}
+            />
+            <input
+              className="border rounded p-1 w-full"
+              placeholder={t('workspace.tasks.assignee')}
+              value={newTask.assigneeUpn}
+              onChange={(e) => setNewTask({ ...newTask, assigneeUpn: e.target.value })}
+            />
+            <input
+              className="border rounded p-1 w-full"
+              placeholder={t('workspace.tasks.new')}
+              value={newTask.title}
+              onChange={(e) => setNewTask({ ...newTask, title: e.target.value })}
+            />
+            <textarea
+              className="border rounded p-1 w-full"
+              placeholder={t('workspace.tasks.new')}
+              value={newTask.description}
+              onChange={(e) =>
+                setNewTask({ ...newTask, description: e.target.value })
+              }
+            />
+            <button className="bg-blue-600 text-white px-2 rounded" type="submit">
+              {t('workspace.tasks.new')}
+            </button>
+          </form>
+        </div>
+      </div>
+      <div className="border rounded p-2 h-40 overflow-y-auto">
+        <h3 className="font-semibold mb-2">{t('workspace.activity.title')}</h3>
+        {activity.map((a, idx) => (
+          <div key={idx} className="text-sm">
+            {new Date(a.createdAt).toLocaleTimeString()} - {a.kind}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -40,5 +40,31 @@
     "cancel": "Cancel",
     "submit": "Trigger",
     "triggered": "Playbook triggered"
+  },
+  "workspace": {
+    "title": "Workspace",
+    "chat": {
+      "title": "Incident Chat",
+      "placeholder": "Type a message",
+      "send": "Send"
+    },
+    "tasks": {
+      "title": "Tasks",
+      "new": "New Task",
+      "assignee": "Assignee UPN",
+      "role": "Role",
+      "status": "Status"
+    },
+    "activity": {
+      "title": "Activity"
+    }
+  },
+  "task": {
+    "status": {
+      "open": "Open",
+      "in_progress": "In Progress",
+      "done": "Done",
+      "cancelled": "Cancelled"
+    }
   }
 }

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -40,5 +40,31 @@
     "cancel": "Annuler",
     "submit": "Déclencher",
     "triggered": "Playbook déclenché"
+  },
+  "workspace": {
+    "title": "Espace de travail",
+    "chat": {
+      "title": "Chat de l'incident",
+      "placeholder": "Écrire un message",
+      "send": "Envoyer"
+    },
+    "tasks": {
+      "title": "Tâches",
+      "new": "Nouvelle tâche",
+      "assignee": "UPN du responsable",
+      "role": "Rôle",
+      "status": "Statut"
+    },
+    "activity": {
+      "title": "Activité"
+    }
+  },
+  "task": {
+    "status": {
+      "open": "Ouverte",
+      "in_progress": "En cours",
+      "done": "Terminée",
+      "cancelled": "Annulée"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add incident chat, tasks, and activity endpoints in incident-svc
- create incident workspace page with chat, tasks, and activity panels
- add database migrations for chat messages and task fields, plus EN/FR strings

## Testing
- `pnpm --filter incident-svc test` *(fails: Cannot find module '@tactix/lib-db/dist/index.js')*
- `pnpm --filter ui-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a13a05c50c83239be84453d6b08a32