### PR TITLE
feat(incident-svc): add time utilities

### DIFF
--- a/services/incident-svc/dist/lib/time.js
+++ b/services/incident-svc/dist/lib/time.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.durationHours = durationHours;
+exports.clampToHorizon = clampToHorizon;
+function durationHours(startsAt, endsAt) {
+    const start = new Date(startsAt);
+    const end = new Date(endsAt);
+    const ms = end.getTime() - start.getTime();
+    return ms / (1000 * 60 * 60);
+}
+function clampToHorizon(date, horizonDays, now = new Date()) {
+    const target = new Date(date);
+    const min = new Date(now.getTime() - horizonDays * 24 * 60 * 60 * 1000);
+    const max = new Date(now.getTime() + horizonDays * 24 * 60 * 60 * 1000);
+    if (target < min)
+        return min;
+    if (target > max)
+        return max;
+    return target;
+}

--- a/services/incident-svc/src/lib/time.ts
+++ b/services/incident-svc/src/lib/time.ts
@@ -1,0 +1,15 @@
+export function durationHours(startsAt: Date | string, endsAt: Date | string): number {
+  const start = new Date(startsAt);
+  const end = new Date(endsAt);
+  const ms = end.getTime() - start.getTime();
+  return ms / (1000 * 60 * 60);
+}
+
+export function clampToHorizon(date: Date | string, horizonDays: number, now: Date = new Date()): Date {
+  const target = new Date(date);
+  const min = new Date(now.getTime() - horizonDays * 24 * 60 * 60 * 1000);
+  const max = new Date(now.getTime() + horizonDays * 24 * 60 * 60 * 1000);
+  if (target < min) return min;
+  if (target > max) return max;
+  return target;
+}

--- a/services/incident-svc/test/time.test.js
+++ b/services/incident-svc/test/time.test.js
@@ -1,0 +1,22 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { durationHours, clampToHorizon } = require('../dist/lib/time.js');
+
+test('durationHours computes whole and fractional hours', () => {
+  const start = '2025-08-17T10:00:00Z';
+  const end = '2025-08-18T10:00:00Z';
+  assert.strictEqual(durationHours(start, end), 24);
+  const end2 = '2025-08-17T11:30:00Z';
+  assert.strictEqual(durationHours(start, end2), 1.5);
+});
+
+test('clampToHorizon enforces bounds around now', () => {
+  const now = new Date('2025-01-01T00:00:00Z');
+  const horizon = 30;
+  const past = new Date('2024-11-30T00:00:00Z');
+  const future = new Date('2025-02-15T00:00:00Z');
+  const within = new Date('2025-01-10T00:00:00Z');
+  assert.deepStrictEqual(clampToHorizon(past, horizon, now), new Date('2024-12-02T00:00:00.000Z'));
+  assert.deepStrictEqual(clampToHorizon(within, horizon, now), within);
+  assert.deepStrictEqual(clampToHorizon(future, horizon, now), new Date('2025-01-31T00:00:00.000Z'));
+});


### PR DESCRIPTION
## Summary
- add durationHours and clampToHorizon helpers for scheduling logic
- test time helpers

## Testing
- `node --test services/incident-svc/test/time.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a1a65360a083239016aa26ee83535a