### PR TITLE
feat: add shared authz package and secure gateway

### DIFF
--- a/gateway/package.json
+++ b/gateway/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tactix/gateway",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "http-proxy": "^1.18.1",
+    "cors": "^2.8.5",
+    "@tactix/authz": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30",
+    "typescript": "^5.4.5"
+  }
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -1,0 +1,124 @@
+import express from 'express';
+import http from 'http';
+import httpProxy from 'http-proxy';
+import cors from 'cors';
+import {
+  verifyJwtRS256,
+  roleMapperFromEnv,
+  resolveRoles,
+  type AuthenticatedRequest,
+} from '@tactix/authz';
+
+const PORT = Number(process.env.PORT || 8080);
+const API_TARGET = process.env.API_TARGET || 'http://incident-svc:3000';
+const RT_TARGET = process.env.RT_TARGET || 'http://realtime-svc:3000';
+const PUBLIC_JWT_KEY = (process.env.PUBLIC_JWT_KEY || '').replace(/\\n/g, '\n');
+
+const { verify } = verifyJwtRS256(PUBLIC_JWT_KEY);
+const ROLE_MAPPER = roleMapperFromEnv();
+const proxy = httpProxy.createProxyServer({ changeOrigin: true });
+
+proxy.on('proxyReq', (proxyReq, req) => {
+  const auth = req.headers['authorization'];
+  if (auth) proxyReq.setHeader('Authorization', auth);
+});
+
+const app = express();
+app.use(
+  cors({
+    origin: true,
+    credentials: true,
+    allowedHeaders: ['Authorization', 'Content-Type'],
+  })
+);
+
+app.get('/health', (_req, res) => {
+  res.json({ ok: true, ts: new Date().toISOString() });
+});
+
+function authMiddleware(req: AuthenticatedRequest, res: express.Response, next: express.NextFunction) {
+  const header = req.headers['authorization'];
+  const cid = req.headers['x-correlation-id'] || Math.random().toString(36).slice(2);
+  if (!header || !header.startsWith('Bearer ')) {
+    console.warn('auth failure', { reason: 'missing', path: req.path, cid });
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  try {
+    const payload: any = verify(header.slice(7));
+    const ad_groups = Array.isArray(payload.ad_groups) ? payload.ad_groups : [];
+    req.user = {
+      upn: payload.upn || payload.sub,
+      name: payload.name,
+      ad_groups,
+      roles: resolveRoles(ad_groups, ROLE_MAPPER),
+    };
+    console.debug('auth success', { upn: req.user.upn, roles: req.user.roles });
+    next();
+  } catch {
+    console.warn('auth failure', { reason: 'invalid', path: req.path, cid });
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+}
+
+const allow = [/^\/auth\//, /^\/health$/, /^\/api-docs\//];
+app.use((req, res, next) => {
+  if (allow.some((r) => r.test(req.path))) return next();
+  if (req.path.startsWith('/api/')) return authMiddleware(req as any, res, next);
+  next();
+});
+
+app.use('/api', (req, res) => {
+  proxy.web(req, res, { target: API_TARGET }, (err) => {
+    console.warn('proxy error', err.message);
+    res.status(502).end();
+  });
+});
+
+const server = http.createServer(app);
+
+function extractToken(req: http.IncomingMessage) {
+  const proto = req.headers['sec-websocket-protocol'];
+  if (proto) {
+    const parts = proto.split(',').map((p) => p.trim());
+    if (parts[0] === 'bearer' && parts[1]) return parts[1];
+  }
+  try {
+    const url = new URL(req.url || '', 'http://localhost');
+    const q = url.searchParams.get('token');
+    if (q) return q;
+  } catch {}
+  return null;
+}
+
+server.on('upgrade', (req: AuthenticatedRequest, socket, head) => {
+  if (!req.url || !req.url.startsWith('/rt')) {
+    socket.destroy();
+    return;
+  }
+  const token = extractToken(req);
+  if (!token) {
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+    return;
+  }
+  try {
+    const payload: any = verify(token);
+    const ad_groups = Array.isArray(payload.ad_groups) ? payload.ad_groups : [];
+    req.user = {
+      upn: payload.upn || payload.sub,
+      name: payload.name,
+      ad_groups,
+      roles: resolveRoles(ad_groups, ROLE_MAPPER),
+    };
+    console.debug('ws auth success', { upn: req.user.upn, roles: req.user.roles });
+    proxy.ws(req, socket, head, { target: RT_TARGET });
+  } catch {
+    console.warn('ws auth failure', { path: req.url });
+    socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+    socket.destroy();
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`gateway listening on ${PORT}`);
+});

--- a/gateway/tsconfig.json
+++ b/gateway/tsconfig.json
@@ -3,12 +3,10 @@
     "target": "ES2020",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["src"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src"]
 }

--- a/packages/authz/README.md
+++ b/packages/authz/README.md
@@ -1,0 +1,18 @@
+# @tactix/authz
+
+Shared authorization helpers for TACTIX services.
+
+## Role Mapping
+
+Roles are derived from the `ROLE_MAPPING_JSON` environment variable. Example:
+
+```
+{
+  ".*_DO$": ["DO"],
+  ".*_IMO$": ["IMO"],
+  "G3_OPS": ["G3 OPS"],
+  "Admins": ["ADMIN"]
+}
+```
+
+Each key is treated as a regular expression matched against a user's AD groups.

--- a/packages/authz/package.json
+++ b/packages/authz/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tactix/authz",
   "version": "0.1.0",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": ["dist"],

--- a/packages/authz/src/index.test.ts
+++ b/packages/authz/src/index.test.ts
@@ -1,94 +1,108 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import jwt from 'jsonwebtoken';
-import { verifyJwtRS256, decodeJwt } from './index';
-import type { Request, Response } from 'express';
+import {
+  verifyJwtRS256,
+  roleMapperFromEnv,
+  resolveRoles,
+  requireRole,
+  type AuthenticatedRequest,
+} from './index';
+import type { Response } from 'express';
 
-// Simple RSA key pair for tests (generated for testing only)
-const PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----
-MIICXQIBAAKBgQCr4Hknc0NrF4P3nPuCXHDBPPfQtbDNRsTA70vsK1tnE+bBZ5qT
-L0U8nyCLlcQFVJHhtq/Y5cHIxHmr18bODsPwhj/KgOMGNJUgIAQ9PEG8D1g0K1T0
-xTGVtC6zqD2c/Ik2Vq6KYFAsktwVDqveufqdpypu32n7Z1xXHrp236UMtQIDAQAB
-AoGAZmkavRKu0kUQeFk/gQq/i323iDL49myIIZeF1P0uohsEiL/KZ8nfdXbra+XU
-4mVTRu6YQ8VE3d2rYZRk5v0zzakDx4zY/boYYGr2susx6bwyodH4qzM7gc3KJ2Yj
-p8BgE4nn3OJbGdv8ImZ/Sc7VcRbP5hqjv3Vv4Y20N6l04QECQQDlF6UVx/FuWRzE
-6VLdystD5nq2WEYLRh3SeDsICoZ6irMIXja+6JGZveHFkNjEcNWef39/C4R2tQeM
-/fi91tILAkEAuifaRl6VwBEm90Lk9R/+qvOB0fOkH1ZZ1xd6QbaO5jM90oCbGyF2
-fs/3Gzdh0dX8GZFODdgNpTi27C/7fyqCkQJBALuLHcEGoVYLRNvKcJsteVEh9Up7
-P88GJEqn3Ejj6inUeJ8V+RaH//RUW2KIiMzFxLpy0X58F3RDeo63eNbUsGECQCBt
-TJS3BM4tiTqcKoy0eZZ+j9RnBbTK1Z4VBPakiobP6KyHR+Y6z+4PSJVpaz6RtWLw
-HtkobaN6D+PfYZ7RUTECQQCxKCGbdJrYzsaLxwDyZaG0/gt0XiY8h1NIsDPKySx1
-d7zbIR3IgwxM/H2ymlk/wEYBLETymFcpnSUsctNk6heF
------END RSA PRIVATE KEY-----`;
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDocKY5H8ackf+k
+t9KoWJqxZ3x8tIo3K2F9cxf1EOsarSNPk+G4x+ETnWxiJ9rZ5a/F4o0EwC3tXwhd
+r8BQUDSVh1LlZyB76iufPDBcSmmQs+65tpwTb8W4WVD3c3LU8n9n80RgzKWB1jok
+FfJXJqDLTH4wUhJbYrAWsqk73eUlIPvDKnf2Ywvl2zfNPaUiGm/Kx6Rs+IrrXgKa
+2scAZG0wg8zrJpVtgnkmnWO46dTr1k77adfZ/8C1QEEsQCJNXMJmEfUnSpxG5af7
+O9i12JBJBuFBz6fVovgJUy4pEUPOf/U86M/uIdyIEab1nXoD1Fzk4jpdk+b9FFGt
+ym/jRKqtAgMBAAECggEAEnABF23oVLoWA6xbJuRkXOcfDktJ3WdxA8Dx6QwPAh4y
+u1i5Im2kcmhd1QlhSEB6aWF3myVdX0NXCAttX1GFYkkKL8022+1uyWI+WcvDROmo
+6Y1NIxOOJPncvMwpEzArIAVBasZA6KQkF4GwJ+6V+ZpXNiEEeMBCxIImf2uyBfhJ
+nAK15IAhFnYjGSwkRTe/dxZfwY2dzeaeju9nnZ4OxLtrDQem5uiuQ/1uD1qDt60p
+pBtwEqmRGWYAPl8K8PbcW+qKClA+2NIvvIPF8tzZJXZrMfCngB2Z42HH1luBzQCh
+lHowQ8alCIwX84uosQ/7epw8spiEgaNbYizxS9TgMQKBgQD3oQ7IXytZTdPX8GAb
+4Hf2PhJVhjaTrCXvyJ+4jk8gmYXMgvL/fyGHqe+JP6MtSZ0MMwku6nUtfPnkPtRQ
+aRKCTGl3ZvWOymwjbvAe7gJhKsWaITX9eM8Y/xN+jBQyAsakFrJlFN+ZXuJxzleH
+h+KmvPXmvsg1NrFJbKt0/JEJdQKBgQDwTCXJMAxbktKIGvOTe0y0ptcySyypfQAo
+aZZBcA489wK9Yx6Ja4GPPCJKaxCtx6ffwy2oaeh/OmMwXfTab3dReFYuLb2RNpgr
+gNI9esc83enJUDpBmvH1sYzd30FdT//OnsBESqZctaZB5qiMcAr/LoLnEWcbRk6x
+aMWTxMm9WQKBgQDTKcZ/W5iNqO5zgAmU/A+QLlJYGAFGYFBhb4W0TbZwKDqOsUQi
+V/jxxRn8wgWWQuXnV0YHeeu+hIpb9q/6ef9MmXh+V5Ai2b7pYFrnJTNmRKEI1DVE
+FtcTi8DF8xHtq6xUlP4/cFNUaDNVtQ2zB09hvFU9FYeIyUDZSg/TzOSpWQKBgCbn
+/Vo0uFt/Sy0USAnB9ept9PvEpiePAJ6KcfSIYxXF3KCzUrdnO6PoVZj8+sdYQzr8
+jADvnOA0oOis3b8cOxJqzHFPoJjJYRvyEJg5r9aQC5E3tyb2ImToaWlnA1tLX5yh
+oXmtKIBsPM4AvZt3bKBidHlbHPmSiZ053HuPaiaJAoGAI61SwjOoL08kAJ4Ql5aV
+5VObA7iH6hprRXe9hjsZg85xxQqZqXhfs6O2GRgB/3OJqvhlT6W7tBCMY8KzAWKb
+cpYENWXriS2Bhu7iJO5JaQsz0R+pyjDTs2/HKOEVU7geV9ZC79T8nKB6nNNSkMDM
+HGPPsiSJ4U/p8lvFe02dRH0=
+-----END PRIVATE KEY-----`;
 
 const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
-MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgQCr4Hknc0NrF4P3nPuCXHDBPPfQ
-tbDNRsTA70vsK1tnE+bBZ5qTL0U8nyCLlcQFVJHhtq/Y5cHIxHmr18bODsPwhj/K
-gOMGNJUgIAQ9PEG8D1g0K1T0xTGVtC6zqD2c/Ik2Vq6KYFAsktwVDqveufqdpypu
-32n7Z1xXHrp236UMtQIDAQAB
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6HCmOR/GnJH/pLfSqFia
+sWd8fLSKNythfXMX9RDrGq0jT5PhuMfhE51sYifa2eWvxeKNBMAt7V8IXa/AUFA0
+lYdS5Wcge+ornzwwXEppkLPuubacE2/FuFlQ93Ny1PJ/Z/NEYMylgdY6JBXyVyag
+y0x+MFISW2KwFrKpO93lJSD7wyp39mML5ds3zT2lIhpvysekbPiK614CmtrHAGRt
+MIPM6yaVbYJ5Jp1juOnU69ZO+2nX2f/AtUBBLEAiTVzCZhH1J0qcRuWn+zvYtdiQ
+SQbhQc+n1aL4CVMuKRFDzn/1POjP7iHciBGm9Z16A9Rc5OI6XZPm/RRRrcpv40Sq
+rQIDAQAB
 -----END PUBLIC KEY-----`;
 
-describe('verifyJwtRS256 middleware', () => {
-  const mw = verifyJwtRS256(PUBLIC_KEY);
+describe('verifyJwtRS256', () => {
+  const jwtTools = verifyJwtRS256(PUBLIC_KEY);
 
-  it('passes with valid token', () => {
-    const token = jwt.sign({ sub: 'alice', ad_groups: ['OPS_X'] }, PRIVATE_KEY, {
+  it('accepts valid token', () => {
+    const token = jwt.sign({ sub: 'alice' }, PRIVATE_KEY, {
       algorithm: 'RS256',
       expiresIn: '1h',
     });
-    const req: any = { headers: { authorization: `Bearer ${token}` } };
-    const res: any = { status: (_: number) => res, json: (_: any) => res };
-    let called = false;
-    mw(req as Request, res as Response, () => {
-      called = true;
-    });
-    expect(called).toBe(true);
-    expect(req.user?.upn).toBe('alice');
+    const payload = jwtTools.verify(token) as any;
+    expect(payload.sub).toBe('alice');
   });
 
   it('rejects expired token', () => {
-    const token = jwt.sign(
-      { sub: 'alice', ad_groups: [], exp: Math.floor(Date.now() / 1000) - 10 },
-      PRIVATE_KEY,
-      { algorithm: 'RS256' }
-    );
-    const req: any = { headers: { authorization: `Bearer ${token}` } };
-    let status = 200;
-    const res: any = {
-      status: (s: number) => {
-        status = s;
-        return res;
-      },
-      json: () => res,
-    };
-    mw(req as Request, res as Response, () => {});
-    expect(status).toBe(401);
+    const token = jwt.sign({ sub: 'alice', exp: Math.floor(Date.now()/1000) - 10 }, PRIVATE_KEY, {
+      algorithm: 'RS256',
+    });
+    expect(() => jwtTools.verify(token)).toThrow();
   });
 
-  it('rejects signature mismatch', () => {
+  it('rejects bad signature', () => {
     const other = jwt.sign({ sub: 'bob' }, PRIVATE_KEY, {
       algorithm: 'RS256',
     });
-    const req: any = { headers: { authorization: `Bearer ${other}` } };
-    let status = 200;
-    const res: any = {
-      status: (s: number) => {
-        status = s;
-        return res;
-      },
-      json: () => res,
-    };
-    mw(req as Request, res as Response, () => {});
-    expect(status).toBe(401);
+    const otherTools = verifyJwtRS256('-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApR6UytzszbmWzxubUoil\nm0ytehZMhUlCT3VkOITkkpFmS6r30YIOCwVDDDeWGPA7eGRIDcH+xr3aMcMBXNIN\n61WGy7kYEcCkZBHwNOpyYOux/Q3ZxLE3TltDJoZ8msdT4eJOOFbg0zu1zD8SWu6j\n7U8J0uIK4WMbe6PfUu8tkFncraEw9loMZEvUyMjyC5sma6AsVzTdDEr1xgG+Z6kT\nj7yvGN28AL/fOHnqd7qV3CyMfCVxYvBy06SnVAk0nnBYnCTsRmRykGGBqBPdZiZB\nI2sMSmc5QwDFi1Cdm42Hcps225y7sY9qsK0kGugHgd6Nq35p3xNmPR9U1FVLtZL1\n0wIDAQAB\n-----END PUBLIC KEY-----');
+    expect(() => otherTools.verify(other)).toThrow();
   });
 });
 
-describe('decodeJwt', () => {
-  it('maps roles from ad groups', () => {
-    process.env.ROLE_MAPPING_JSON = '{"^OPS_": ["VIEWER"]}';
-    const token = jwt.sign({ sub: 'alice', ad_groups: ['OPS_1'] }, PRIVATE_KEY, {
-      algorithm: 'RS256',
-    });
-    const user = decodeJwt(token, PUBLIC_KEY);
-    expect(user.roles).toContain('VIEWER');
+describe('role mapping', () => {
+  beforeEach(() => {
+    process.env.ROLE_MAPPING_JSON = '{".*_DO$": ["DO"], "G3_OPS": ["G3 OPS"]}';
+  });
+
+  it('maps roles using regex', () => {
+    const mapper = roleMapperFromEnv();
+    const roles = resolveRoles(['OPNAMEXX-X_DO', 'G3_OPS'], mapper);
+    expect(roles).toContain('DO');
+    expect(roles).toContain('G3 OPS');
+  });
+});
+
+describe('requireRole', () => {
+  it('returns 403 when role missing', () => {
+    const req: AuthenticatedRequest = { user: { upn: 'a', ad_groups: [], roles: [] } } as any;
+    let status = 200;
+    const res: Response = {
+      status(code: number) {
+        status = code;
+        return this as any;
+      },
+      json() { return this; },
+    } as any;
+    let called = false;
+    requireRole(['DO'])(req, res, () => { called = true; });
+    expect(status).toBe(403);
+    expect(called).toBe(false);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,25 @@ importers:
         specifier: ^5.4.5
         version: 5.9.2
 
+  packages/authz:
+    dependencies:
+      jsonwebtoken:
+        specifier: ^9.0.0
+        version: 9.0.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.11
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.11)
+
   packages/lib-db:
     dependencies:
       pg:
@@ -131,9 +150,9 @@ importers:
 
   services/incident-svc:
     dependencies:
-      '@tactix/auth':
+      '@tactix/authz':
         specifier: workspace:*
-        version: link:../../packages/auth
+        version: link:../../packages/authz
       '@tactix/lib-db':
         specifier: workspace:*
         version: link:../../packages/lib-db
@@ -146,6 +165,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.21.2
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -163,8 +185,36 @@ importers:
         specifier: ^5.4.5
         version: 5.9.2
 
+  services/orders-svc:
+    dependencies:
+      '@tactix/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
+      '@tactix/lib-db':
+        specifier: workspace:*
+        version: link:../../packages/lib-db
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^4.18.2
+        version: 4.21.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.11
+      typescript:
+        specifier: ^5.4.5
+        version: 5.9.2
+
   services/playbook-svc:
     dependencies:
+      '@tactix/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
       express:
         specifier: ^4.19.2
         version: 4.21.2
@@ -206,6 +256,9 @@ importers:
 
   services/realtime-svc:
     dependencies:
+      '@tactix/authz':
+        specifier: workspace:*
+        version: link:../../packages/authz
       '@tactix/lib-db':
         specifier: workspace:*
         version: link:../../packages/lib-db


### PR DESCRIPTION
## Summary
- add shared @tactix/authz package for JWT verification, role mapping, and express helpers
- protect realtime-svc websocket upgrade with role resolution
- introduce gateway service with auth middleware, CORS, and token-checked /rt proxy

## Testing
- `pnpm --filter @tactix/authz test`
- `pnpm --filter @tactix/authz build`
- `pnpm install --filter @tactix/gateway` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm --filter @tactix/gateway build` *(fails: missing modules due to previous install error)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c07649d483238b1fd83326eff836