### PR TITLE
feat(auth-service): expose openapi and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
     "test": "pnpm -r test",
+    "test:ci": "pnpm -r test",
     "migrate": "pnpm -r migrate"
   }
 }

--- a/services/auth-service/index.js
+++ b/services/auth-service/index.js
@@ -71,7 +71,16 @@ function ldapAuthenticate(upn, password) {
 }
 
 app.get('/health', (_req, res) => {
-  res.json({ ok: true });
+  res.json({ ok: true, ts: new Date().toISOString() });
+});
+
+app.get('/openapi.json', (_req, res) => {
+  // Serve static OpenAPI definition for this service
+  // Keeping it simple and synchronous as the document is small
+  // and does not require dynamic generation.
+  // eslint-disable-next-line global-require
+  const spec = require('./openapi.json');
+  res.json(spec);
 });
 
 app.post('/login', async (req, res) => {
@@ -119,6 +128,10 @@ app.post('/refresh', (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`auth-service listening on ${PORT}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`auth-service listening on ${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/services/auth-service/openapi.json
+++ b/services/auth-service/openapi.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "auth-service",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Service is healthy"
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "summary": "Authenticate and receive JWTs",
+        "responses": {
+          "200": {
+            "description": "JWT pair"
+          },
+          "400": {
+            "description": "Missing credentials"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          }
+        }
+      }
+    },
+    "/refresh": {
+      "post": {
+        "summary": "Refresh access token",
+        "responses": {
+          "200": {
+            "description": "New access token"
+          },
+          "400": {
+            "description": "Missing token"
+          },
+          "401": {
+            "description": "Invalid refresh token"
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/auth-service/package.json
+++ b/services/auth-service/package.json
@@ -5,12 +5,16 @@
   "scripts": {
     "build": "echo 'no build'",
     "start": "node index.js",
-    "test": "echo \"No tests\""
+    "test": "vitest run"
   },
   "dependencies": {
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.0",
     "dotenv": "^16.4.5",
     "ldapjs": "^2.3.3"
+  },
+  "devDependencies": {
+    "supertest": "^6.3.3",
+    "vitest": "^0.34.6"
   }
 }

--- a/services/auth-service/tests/auth.test.js
+++ b/services/auth-service/tests/auth.test.js
@@ -1,0 +1,27 @@
+import request from 'supertest';
+import { describe, it, expect } from 'vitest';
+
+// Provide dummy key so jwt.verify does not throw for missing key
+process.env.JWT_PUBLIC_KEY = 'test-key';
+
+// eslint-disable-next-line import/first
+import app from '../index.js';
+
+describe('auth-service', () => {
+  it('GET /health returns ok response', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(typeof res.body.ts).toBe('string');
+  });
+
+  it('POST /login without credentials returns 400', async () => {
+    const res = await request(app).post('/login').send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /refresh with invalid token returns 401', async () => {
+    const res = await request(app).post('/refresh').send({ refresh: 'bad' });
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add timestamped /health and static /openapi.json endpoints to auth-service
- export express app for testing and conditionally start server
- introduce vitest-based smoke tests for auth-service
- add root test:ci script

## Testing
- `pnpm --filter auth-service test` *(fails: vitest not found)*
- `pnpm test:ci` *(fails: auth-service@0.1.0 test: vitest run: spawn ENOENT)*


------
https://chatgpt.com/codex/tasks/task_e_68a1c82ec680832382ff530fe59791fe