### PR TITLE
feat(uiux): skeleton operator ui routes and i18n

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -11,6 +11,7 @@
     <script src="https://unpkg.com/react-i18next@13.0.0/dist/umd/react-i18next.min.js"></script>
     <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
     <script src="/config.js"></script>
+    <link rel="stylesheet" href="src/design/tokens.css" />
   </head>
   <body class="bg-gray-100 text-gray-800">
     <div id="root"></div>

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -3,10 +3,17 @@ import { useTranslation } from 'react-i18next';
 
 export default function Sidebar() {
   const { t } = useTranslation();
+  const engEnabled = (window as any).ENV?.ENG_CHAT_ENABLED !== false;
   return (
     <aside className="w-48 bg-gray-100 p-4 space-y-2 text-sm">
+      <Link to="/operations" className="block hover:underline">
+        {t('nav.operations')}
+      </Link>
       <Link to="/incidents" className="block hover:underline">
         {t('nav.incidents')}
+      </Link>
+      <Link to="/operations/1/schedule" className="block hover:underline">
+        {t('nav.schedule')}
       </Link>
       <Link to="/playbooks" className="block hover:underline">
         {t('nav.playbooks')}
@@ -14,14 +21,13 @@ export default function Sidebar() {
       <Link to="/orders" className="block hover:underline">
         {t('nav.orders')}
       </Link>
-      <Link to="/schedule" className="block hover:underline">
-        {t('nav.schedule')}
-      </Link>
-      <Link to="/chat" className="block hover:underline">
-        {t('nav.chat')}
-      </Link>
-      <Link to="/notifications" className="block hover:underline">
-        {t('nav.notifications')}
+      {engEnabled && (
+        <Link to="/eng" className="block hover:underline">
+          {t('nav.eng')}
+        </Link>
+      )}
+      <Link to="/settings/profile" className="block hover:underline">
+        {t('nav.settings')}
       </Link>
     </aside>
   );

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -1,4 +1,3 @@
-const { Link } = ReactRouterDOM;
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from './LanguageSwitcher.tsx';
 
@@ -6,34 +5,22 @@ export default function TopNav({ onLogout }) {
   const { t } = useTranslation();
   return (
     <header className="flex items-center justify-between bg-gray-800 text-white px-4 py-2">
-      <div className="font-bold">TACTIX</div>
-      <nav className="flex gap-4 text-sm">
-        <Link to="/incidents" className="hover:underline">
-          {t('nav.incidents')}
-        </Link>
-        <Link to="/playbooks" className="hover:underline">
-          {t('nav.playbooks')}
-        </Link>
-        <Link to="/orders" className="hover:underline">
-          {t('nav.orders')}
-        </Link>
-        <Link to="/schedule" className="hover:underline">
-          {t('nav.schedule')}
-        </Link>
-        <Link to="/chat" className="hover:underline">
-          {t('nav.chat')}
-        </Link>
-        <Link to="/notifications" className="hover:underline">
-          {t('nav.notifications')}
-        </Link>
-      </nav>
+      <div className="flex items-center gap-2">
+        <div className="font-bold">TACTIX</div>
+        <select className="text-black text-sm rounded px-1 py-0.5" aria-label={t('nav.operations')}>
+          <option>OP1</option>
+        </select>
+      </div>
+      <input
+        type="search"
+        placeholder={t('header.search.placeholder')}
+        className="flex-1 mx-4 max-w-md text-black rounded px-2 py-1 text-sm"
+      />
       <div className="flex items-center gap-4">
+        <button aria-label={t('header.notifications')}>🔔</button>
         <LanguageSwitcher />
-        <button
-          onClick={onLogout}
-          className="text-sm hover:underline"
-        >
-          {t('nav.logout')}
+        <button onClick={onLogout} className="text-sm hover:underline">
+          {t('header.logout')}
         </button>
       </div>
     </header>

--- a/ui/src/design/Button.tsx
+++ b/ui/src/design/Button.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export default function Button({ variant = 'primary', className = '', ...rest }: ButtonProps) {
+  const base = 'px-3 py-1 rounded text-sm focus:outline-none focus:ring';
+  const styles: Record<string, string> = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700',
+    secondary: 'bg-gray-200 text-gray-800 hover:bg-gray-300',
+  };
+  return (
+    <button
+      className={`${base} ${styles[variant]} ${className}`}
+      {...rest}
+    />
+  );
+}

--- a/ui/src/design/tokens.css
+++ b/ui/src/design/tokens.css
@@ -1,0 +1,17 @@
+:root {
+  --spacing-xs: 0.25rem;
+  --spacing-sm: 0.5rem;
+  --spacing-md: 1rem;
+  --spacing-lg: 1.5rem;
+  --radius-sm: 0.125rem;
+  --radius-md: 0.25rem;
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --z-modal: 1000;
+  --color-bg: #f9fafb;
+  --color-surface: #ffffff;
+  --color-text: #1f2937;
+  --color-success: #16a34a;
+  --color-warn: #f59e0b;
+  --color-danger: #dc2626;
+  --color-info: #3b82f6;
+}

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -14,12 +14,54 @@
     "playbooks": "Playbooks",
     "schedule": "Schedule",
     "chat": "Chat",
+    "operations": "Operations",
+    "eng": "Eng",
+    "settings": "Settings",
     "logout": "Logout"
+  },
+  "header": {
+    "search": { "placeholder": "Search" },
+    "notifications": "Notifications",
+    "language": "Language",
+    "logout": "Logout"
+  },
+  "footer": {
+    "build": "Build"
+  },
+  "auth": {
+    "login": {
+      "title": "Sign in",
+      "upn": "UPN",
+      "password": "Password",
+      "submit": "Sign in"
+    }
   },
   "warlog": {
     "title": "Warlog",
     "empty": "No entries yet.",
     "quickEntryTitle": "Quick Warlog Entry"
+  },
+  "schedule": {
+    "title": "Schedule"
+  },
+  "pb": {
+    "title": "Playbooks"
+  },
+  "orders": {
+    "list": { "title": "Orders" }
+  },
+  "settings": {
+    "profile": "Profile",
+    "admin": "Admin"
+  },
+  "common": {
+    "save": "Save",
+    "cancel": "Cancel",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirm": "Confirm",
+    "error": "Something went wrong",
+    "notFound": "Not found"
   },
   "chat": {
     "title": "Live Chat",
@@ -30,6 +72,7 @@
   "eng": {
     "title": "Engineering Chat (ENGNET)",
     "unofficial": "Unofficial",
+    "rooms": "Rooms",
     "send": "Send",
     "promote": "Promote to Warlog"
   },

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -14,12 +14,54 @@
     "playbooks": "Playbooks",
     "schedule": "Horaire",
     "chat": "Chat",
+    "operations": "Opérations",
+    "eng": "Eng",
+    "settings": "Paramètres",
     "logout": "Déconnexion"
+  },
+  "header": {
+    "search": { "placeholder": "Recherche" },
+    "notifications": "Notifications",
+    "language": "Langue",
+    "logout": "Déconnexion"
+  },
+  "footer": {
+    "build": "Version"
+  },
+  "auth": {
+    "login": {
+      "title": "Connexion",
+      "upn": "UPN",
+      "password": "Mot de passe",
+      "submit": "Connexion"
+    }
   },
   "warlog": {
     "title": "Journal de guerre",
     "empty": "Aucune entrée pour le moment.",
     "quickEntryTitle": "Entrée rapide au journal"
+  },
+  "schedule": {
+    "title": "Horaire"
+  },
+  "pb": {
+    "title": "Playbooks"
+  },
+  "orders": {
+    "list": { "title": "Ordres" }
+  },
+  "settings": {
+    "profile": "Profil",
+    "admin": "Admin"
+  },
+  "common": {
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "confirm": "Confirmer",
+    "error": "Une erreur s'est produite",
+    "notFound": "Introuvable"
   },
   "chat": {
     "title": "Chat en direct",
@@ -30,6 +72,7 @@
   "eng": {
     "title": "Chat d'ingénierie (ENGNET)",
     "unofficial": "Non officiel",
+    "rooms": "Salles",
     "send": "Envoyer",
     "promote": "Promouvoir au journal"
   },

--- a/ui/src/pages/EngRoom.tsx
+++ b/ui/src/pages/EngRoom.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+export default function EngRoom() {
+  const { t } = useTranslation();
+  const { roomId } = useParams();
+  return (
+    <div className="text-sm">
+      {t('eng.title')} {roomId}
+    </div>
+  );
+}

--- a/ui/src/pages/EngRooms.tsx
+++ b/ui/src/pages/EngRooms.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function EngRooms() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('eng.rooms')}</div>;
+}

--- a/ui/src/pages/ErrorPage.tsx
+++ b/ui/src/pages/ErrorPage.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function ErrorPage() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('common.error')}</div>;
+}

--- a/ui/src/pages/IncidentDashboard.tsx
+++ b/ui/src/pages/IncidentDashboard.tsx
@@ -28,7 +28,7 @@ export default function IncidentDashboard({ token }) {
       body: JSON.stringify({ title: 'New Incident' }),
     })
       .then((res) => res.json())
-      .then((inc) => navigate(`/incidents/${inc.incident_id}`));
+      .then((inc) => navigate(`/incidents/${inc.incident_id}/workspace`));
   };
 
   return (
@@ -59,7 +59,7 @@ export default function IncidentDashboard({ token }) {
         {incidents.map((inc) => (
           <Link
             key={inc.incident_id}
-            to={`/incidents/${inc.incident_id}`}
+            to={`/incidents/${inc.incident_id}/workspace`}
             className="border rounded p-2 space-y-1 hover:bg-gray-50"
           >
             <div className="font-semibold">{inc.title}</div>

--- a/ui/src/pages/NotFound.tsx
+++ b/ui/src/pages/NotFound.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function NotFound() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('common.notFound')}</div>;
+}

--- a/ui/src/pages/OperationOverview.tsx
+++ b/ui/src/pages/OperationOverview.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+export default function OperationOverview() {
+  const { t } = useTranslation();
+  const { opId } = useParams();
+  return (
+    <div className="text-sm">
+      {t('nav.operations')} {opId}
+    </div>
+  );
+}

--- a/ui/src/pages/OperationsList.tsx
+++ b/ui/src/pages/OperationsList.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function OperationsList() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('nav.operations')}</div>;
+}

--- a/ui/src/pages/OrderDetail.tsx
+++ b/ui/src/pages/OrderDetail.tsx
@@ -1,0 +1,12 @@
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+
+export default function OrderDetail() {
+  const { t } = useTranslation();
+  const { orderId } = useParams();
+  return (
+    <div className="text-sm">
+      {t('orders.list.title')} {orderId}
+    </div>
+  );
+}

--- a/ui/src/pages/OrdersList.tsx
+++ b/ui/src/pages/OrdersList.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function OrdersList() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('orders.list.title')}</div>;
+}

--- a/ui/src/pages/PlaybookPage.tsx
+++ b/ui/src/pages/PlaybookPage.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function PlaybookPage() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('pb.title')}</div>;
+}

--- a/ui/src/pages/SchedulePage.tsx
+++ b/ui/src/pages/SchedulePage.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function SchedulePage() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('schedule.title')}</div>;
+}

--- a/ui/src/pages/SettingsAdmin.tsx
+++ b/ui/src/pages/SettingsAdmin.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function SettingsAdmin() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('settings.admin')}</div>;
+}

--- a/ui/src/pages/SettingsProfile.tsx
+++ b/ui/src/pages/SettingsProfile.tsx
@@ -1,0 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
+export default function SettingsProfile() {
+  const { t } = useTranslation();
+  return <div className="text-sm">{t('settings.profile')}</div>;
+}

--- a/ui/tests/i18n.test.js
+++ b/ui/tests/i18n.test.js
@@ -15,18 +15,18 @@ i18next.use(initReactI18next).init({
 
 function Comp() {
   const { t } = useTranslation();
-  return React.createElement('span', null, t('nav.language'));
+  return React.createElement('span', null, t('nav.operations'));
 }
 
 let html = ReactDOMServer.renderToString(
   React.createElement(I18nextProvider, { i18n: i18next }, React.createElement(Comp))
 );
-assert(html.includes('Language'));
+assert(html.includes('Operations'));
 
 i18next.changeLanguage('fr');
 html = ReactDOMServer.renderToString(
   React.createElement(I18nextProvider, { i18n: i18next }, React.createElement(Comp))
 );
-assert(html.includes('Langue'));
+assert(html.includes('Opérations'));
 
 console.log('i18n test passed');


### PR DESCRIPTION
## Summary
- scaffold operator UI routing with placeholders for operations, incidents, orders, playbooks, schedule, engineering chat and settings
- add header with operation selector, search, notifications, language switcher and logout
- introduce design tokens and reusable Button component with expanded i18n keys

## Testing
- `pnpm --filter ui-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a1dceb83f483238a6beba5450afc51