### PR TITLE
feat(ui): add first-run wizard

### DIFF
--- a/docs/first-run-wizard.md
+++ b/docs/first-run-wizard.md
@@ -1,0 +1,15 @@
+# First-Run Wizard
+
+The UI exposes a `/first-run` route that guides initial configuration when `tactix.config.json` is missing or does not define a mode.
+
+## Steps
+1. **Welcome** – intro screen.
+2. **System Check** – calls `GET /bootstrap/probe`.
+3. **Choose Role** – Single, Server, or Client.
+4. **LDAP Configuration** (optional) – test with `POST /auth/ldap/test`.
+5. **Local Admin** (shown if LDAP skipped) – create account via `POST /auth/local/init-admin`.
+6. **Review & Apply** – submit to `POST /bootstrap/config` and reload.
+
+The chosen mode is displayed in the header badge after completion.
+
+

--- a/ui/src/components/MainLayout.tsx
+++ b/ui/src/components/MainLayout.tsx
@@ -3,11 +3,11 @@ import TopNav from './TopNav.tsx';
 import Sidebar from './Sidebar.tsx';
 import GlobalBanner from './GlobalBanner.tsx';
 
-export default function MainLayout({ onLogout }) {
+export default function MainLayout({ onLogout, mode }) {
   return (
     <div className="h-screen flex flex-col">
       <GlobalBanner />
-      <TopNav onLogout={onLogout} />
+      <TopNav onLogout={onLogout} mode={mode} />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <main className="flex-1 overflow-y-auto p-4 bg-white">

--- a/ui/src/components/TopNav.tsx
+++ b/ui/src/components/TopNav.tsx
@@ -1,12 +1,17 @@
 import { useTranslation } from 'react-i18next';
 import LanguageSwitcher from './LanguageSwitcher.tsx';
 
-export default function TopNav({ onLogout }) {
+export default function TopNav({ onLogout, mode }) {
   const { t } = useTranslation();
   return (
     <header className="flex items-center justify-between bg-gray-800 text-white px-4 py-2">
       <div className="flex items-center gap-2">
         <div className="font-bold">TACTIX</div>
+        {mode && (
+          <span className="text-xs bg-blue-600 px-2 py-0.5 rounded">
+            {t(`mode.${mode}`)}
+          </span>
+        )}
         <select className="text-black text-sm rounded px-1 py-0.5" aria-label={t('nav.operations')}>
           <option>OP1</option>
         </select>

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -135,5 +135,50 @@
       "done": "Done",
       "cancelled": "Cancelled"
     }
+  },
+  "mode": {
+    "single": "Single",
+    "server": "Server",
+    "client": "Client"
+  },
+  "firstRun": {
+    "welcome": {
+      "title": "Welcome to TACTIX",
+      "next": "Start"
+    },
+    "systemCheck": {
+      "title": "System Check",
+      "run": "Run Check",
+      "success": "System looks good",
+      "next": "Next"
+    },
+    "chooseRole": {
+      "title": "Choose Role",
+      "local": "Local Client",
+      "server": "Become a Server",
+      "client": "Join a Server",
+      "next": "Next"
+    },
+    "ldap": {
+      "title": "LDAP Configuration",
+      "url": "URL",
+      "bindDn": "Bind DN",
+      "bindPassword": "Bind Password",
+      "baseDn": "Base DN",
+      "test": "Test Connection",
+      "skip": "Skip",
+      "next": "Next"
+    },
+    "localAdmin": {
+      "title": "Create Local Admin",
+      "upn": "Admin UPN",
+      "password": "Password",
+      "create": "Create Admin"
+    },
+    "review": {
+      "title": "Review & Apply",
+      "apply": "Apply",
+      "restart": "Configuration applied. Restarting..."
+    }
   }
 }

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -135,5 +135,50 @@
       "done": "Terminée",
       "cancelled": "Annulée"
     }
+  },
+  "mode": {
+    "single": "Solo",
+    "server": "Serveur",
+    "client": "Client"
+  },
+  "firstRun": {
+    "welcome": {
+      "title": "Bienvenue dans TACTIX",
+      "next": "Commencer"
+    },
+    "systemCheck": {
+      "title": "Vérification du système",
+      "run": "Lancer la vérification",
+      "success": "Le système est prêt",
+      "next": "Suivant"
+    },
+    "chooseRole": {
+      "title": "Choisir le rôle",
+      "local": "Client local",
+      "server": "Devenir un serveur",
+      "client": "Rejoindre un serveur",
+      "next": "Suivant"
+    },
+    "ldap": {
+      "title": "Configuration LDAP",
+      "url": "URL",
+      "bindDn": "Bind DN",
+      "bindPassword": "Mot de passe de liaison",
+      "baseDn": "Base DN",
+      "test": "Tester la connexion",
+      "skip": "Ignorer",
+      "next": "Suivant"
+    },
+    "localAdmin": {
+      "title": "Créer un admin local",
+      "upn": "UPN de l'admin",
+      "password": "Mot de passe",
+      "create": "Créer l'admin"
+    },
+    "review": {
+      "title": "Revoir et appliquer",
+      "apply": "Appliquer",
+      "restart": "Configuration appliquée. Redémarrage..."
+    }
   }
 }

--- a/ui/src/pages/FirstRun.tsx
+++ b/ui/src/pages/FirstRun.tsx
@@ -1,0 +1,170 @@
+import Button from '../design/Button.tsx';
+import { useTranslation } from 'react-i18next';
+const { useState } = React;
+
+interface Props {
+  onComplete: (mode: string) => void;
+}
+
+export default function FirstRun({ onComplete }: Props) {
+  const { t } = useTranslation();
+  const [step, setStep] = useState(0);
+  const [probe, setProbe] = useState('');
+  const [mode, setMode] = useState('');
+  const [ldap, setLdap] = useState({ url: '', bindDn: '', bindPassword: '', baseDn: '' });
+  const [ldapOk, setLdapOk] = useState(false);
+  const [admin, setAdmin] = useState({ upn: '', password: '' });
+
+  const runProbe = () => {
+    fetch('/bootstrap/probe')
+      .then((res) => (res.ok ? res.text() : Promise.reject()))
+      .then((txt) => setProbe(txt))
+      .catch(() => setProbe('fail'));
+  };
+
+  const testLdap = () => {
+    fetch('/auth/ldap/test', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(ldap),
+    })
+      .then((res) => {
+        if (res.ok) {
+          setLdapOk(true);
+        } else {
+          setLdapOk(false);
+        }
+      })
+      .catch(() => setLdapOk(false));
+  };
+
+  const createAdmin = () => {
+    fetch('/auth/local/init-admin', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(admin),
+    })
+      .then((res) => {
+        if (res.ok) {
+          setStep(5);
+        }
+      })
+      .catch(() => {});
+  };
+
+  const applyConfig = () => {
+    const body: any = { mode };
+    if (ldapOk) body.ldap = ldap;
+    fetch('/bootstrap/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+      .then((res) => {
+        if (res.ok) {
+          onComplete(mode);
+          window.location.reload();
+        }
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className="max-w-lg mx-auto p-4 space-y-4">
+      {step === 0 && (
+        <div className="text-center space-y-4">
+          <h2 className="text-xl font-semibold">{t('firstRun.welcome.title')}</h2>
+          <Button onClick={() => setStep(1)}>{t('firstRun.welcome.next')}</Button>
+        </div>
+      )}
+      {step === 1 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{t('firstRun.systemCheck.title')}</h2>
+          <Button onClick={runProbe}>{t('firstRun.systemCheck.run')}</Button>
+          {probe && (
+            <div className="text-sm mt-2">
+              {probe === 'fail' ? t('common.error') : t('firstRun.systemCheck.success')}
+            </div>
+          )}
+          <Button disabled={!probe || probe === 'fail'} onClick={() => setStep(2)}>
+            {t('firstRun.systemCheck.next')}
+          </Button>
+        </div>
+      )}
+      {step === 2 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{t('firstRun.chooseRole.title')}</h2>
+          <div className="flex flex-col gap-2">
+            <Button onClick={() => setMode('single')}>{t('firstRun.chooseRole.local')}</Button>
+            <Button onClick={() => setMode('server')}>{t('firstRun.chooseRole.server')}</Button>
+            <Button onClick={() => setMode('client')}>{t('firstRun.chooseRole.client')}</Button>
+          </div>
+          {mode && (
+            <Button onClick={() => setStep(3)}>{t('firstRun.chooseRole.next')}</Button>
+          )}
+        </div>
+      )}
+      {step === 3 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{t('firstRun.ldap.title')}</h2>
+          <input
+            className="border rounded p-1 w-full"
+            placeholder={t('firstRun.ldap.url')}
+            value={ldap.url}
+            onChange={(e) => setLdap({ ...ldap, url: e.target.value })}
+          />
+          <input
+            className="border rounded p-1 w-full"
+            placeholder={t('firstRun.ldap.bindDn')}
+            value={ldap.bindDn}
+            onChange={(e) => setLdap({ ...ldap, bindDn: e.target.value })}
+          />
+          <input
+            className="border rounded p-1 w-full"
+            type="password"
+            placeholder={t('firstRun.ldap.bindPassword')}
+            value={ldap.bindPassword}
+            onChange={(e) => setLdap({ ...ldap, bindPassword: e.target.value })}
+          />
+          <input
+            className="border rounded p-1 w-full"
+            placeholder={t('firstRun.ldap.baseDn')}
+            value={ldap.baseDn}
+            onChange={(e) => setLdap({ ...ldap, baseDn: e.target.value })}
+          />
+          <div className="flex gap-2">
+            <Button onClick={testLdap}>{t('firstRun.ldap.test')}</Button>
+            <Button onClick={() => setStep(ldapOk ? 5 : 4)}>{t('firstRun.ldap.next')}</Button>
+            <Button onClick={() => setStep(4)}>{t('firstRun.ldap.skip')}</Button>
+          </div>
+        </div>
+      )}
+      {step === 4 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{t('firstRun.localAdmin.title')}</h2>
+          <input
+            className="border rounded p-1 w-full"
+            placeholder={t('firstRun.localAdmin.upn')}
+            value={admin.upn}
+            onChange={(e) => setAdmin({ ...admin, upn: e.target.value })}
+          />
+          <input
+            className="border rounded p-1 w-full"
+            type="password"
+            placeholder={t('firstRun.localAdmin.password')}
+            value={admin.password}
+            onChange={(e) => setAdmin({ ...admin, password: e.target.value })}
+          />
+          <Button onClick={createAdmin}>{t('firstRun.localAdmin.create')}</Button>
+        </div>
+      )}
+      {step === 5 && (
+        <div className="space-y-2">
+          <h2 className="text-lg font-semibold">{t('firstRun.review.title')}</h2>
+          <div className="text-sm">{t(`mode.${mode}`)}</div>
+          <Button onClick={applyConfig}>{t('firstRun.review.apply')}</Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add first-run wizard to guide initial configuration
- show selected mode badge in header
- document first-run flow

## Testing
- `pnpm test` *(fails: services/rbac test ReferenceError: test is not defined)*
- `pnpm --filter ui-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e79fdeb88323a76b005d03101c0d