### PR TITLE
feat(ui): join and promote server flows with TOFU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 dist
 !services/incident-svc/dist/
+tactix.config.json

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -11,6 +11,8 @@ import EngRooms from './src/pages/EngRooms.tsx';
 import EngRoom from './src/pages/EngRoom.tsx';
 import SettingsProfile from './src/pages/SettingsProfile.tsx';
 import SettingsAdmin from './src/pages/SettingsAdmin.tsx';
+import JoinServer from './src/pages/JoinServer.tsx';
+import PromoteServer from './src/pages/PromoteServer.tsx';
 import NotFound from './src/pages/NotFound.tsx';
 import ErrorPage from './src/pages/ErrorPage.tsx';
 import { notifyStore } from './src/lib/notify.ts';
@@ -95,6 +97,7 @@ function App() {
     <I18nextProvider i18n={i18n}>
       <BrowserRouter>
         <Routes>
+          <Route path="/join" element={<JoinServer />} />
           <Route path="/login" element={<Login onLogin={handleLogin} />} />
           <Route
             path="/*"
@@ -128,6 +131,8 @@ function App() {
             )}
             <Route path="settings/profile" element={<SettingsProfile />} />
             <Route path="settings/admin" element={<SettingsAdmin />} />
+            <Route path="settings/join" element={<JoinServer />} />
+            <Route path="settings/promote" element={<PromoteServer />} />
             <Route path="error" element={<ErrorPage />} />
             <Route path="*" element={<NotFound />} />
           </Route>
@@ -181,6 +186,11 @@ function Login({ onLogin }) {
       <Button type="submit" className="w-full">
         {t('auth.login.submit')}
       </Button>
+      <p className="text-center">
+        <a className="text-blue-600" href="/join">
+          {t('connect.joinTitle')}
+        </a>
+      </p>
     </form>
   );
 }

--- a/ui/server.js
+++ b/ui/server.js
@@ -1,10 +1,32 @@
 const express = require('express');
+const fs = require('fs');
+const path = require('path');
+
 const app = express();
 app.use(express.static(__dirname));
+app.use(express.json());
+
+const CONFIG_PATH = path.join(__dirname, '..', 'tactix.config.json');
+
 app.get('/health', (_req, res) => res.json({ ok: true }));
+
 app.get('/config.js', (_req, res) => {
   const enabled = process.env.ENG_ENABLED === 'true' ? 'true' : 'false';
   res.type('application/javascript').send(`window.ENG_ENABLED=${enabled};`);
 });
+
+app.get('/client-config', (_req, res) => {
+  if (fs.existsSync(CONFIG_PATH)) {
+    res.json(JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8')));
+  } else {
+    res.json({});
+  }
+});
+
+app.post('/client-config', (req, res) => {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(req.body, null, 2));
+  res.json({ ok: true });
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`ui listening on ${PORT}`));

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -52,7 +52,9 @@
   },
   "settings": {
     "profile": "Profile",
-    "admin": "Admin"
+    "admin": "Admin",
+    "join": "Join a Server",
+    "promote": "Promote to Server"
   },
   "common": {
     "save": "Save",
@@ -135,5 +137,17 @@
       "done": "Done",
       "cancelled": "Cancelled"
     }
+  },
+  "connect": {
+    "joinTitle": "Join a Server",
+    "discover": "Discover",
+    "manual": "Manual URL",
+    "scan": "Scan QR",
+    "fingerprint": "Fingerprint",
+    "trust": "Trust",
+    "saved": "Server pinned",
+    "promoteTitle": "Promote to Server",
+    "promoteAction": "Promote",
+    "invite": "Invite QR"
   }
 }

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -52,7 +52,9 @@
   },
   "settings": {
     "profile": "Profil",
-    "admin": "Admin"
+    "admin": "Admin",
+    "join": "Rejoindre un serveur",
+    "promote": "Promouvoir en serveur"
   },
   "common": {
     "save": "Enregistrer",
@@ -135,5 +137,17 @@
       "done": "Terminée",
       "cancelled": "Annulée"
     }
+  },
+  "connect": {
+    "joinTitle": "Rejoindre un serveur",
+    "discover": "Découvrir",
+    "manual": "URL manuelle",
+    "scan": "Scanner QR",
+    "fingerprint": "Empreinte",
+    "trust": "Faire confiance",
+    "saved": "Serveur enregistré",
+    "promoteTitle": "Promouvoir en serveur",
+    "promoteAction": "Promouvoir",
+    "invite": "QR d'invitation"
   }
 }

--- a/ui/src/lib/client-config.ts
+++ b/ui/src/lib/client-config.ts
@@ -1,0 +1,17 @@
+export async function savePinnedServer(server) {
+  await fetch('/client-config', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ server }),
+  });
+}
+
+export async function getPinnedServer() {
+  try {
+    const res = await fetch('/client-config');
+    if (!res.ok) return null;
+    return res.json();
+  } catch {
+    return null;
+  }
+}

--- a/ui/src/pages/JoinServer.tsx
+++ b/ui/src/pages/JoinServer.tsx
@@ -1,0 +1,129 @@
+const { useEffect, useState } = React;
+import Button from '../design/Button.tsx';
+import { savePinnedServer } from '../lib/client-config.ts';
+const { useTranslation } = ReactI18next;
+
+export default function JoinServer() {
+  const { t } = useTranslation();
+  const [tab, setTab] = useState('discover');
+  const [servers, setServers] = useState([]);
+  const [url, setUrl] = useState('');
+  const [fingerprint, setFingerprint] = useState('');
+  const [serverId, setServerId] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    if (tab === 'discover') {
+      fetch('/discovery/servers')
+        .then((res) => (res.ok ? res.json() : []))
+        .then((list) => setServers(list || []))
+        .catch(() => setServers([]));
+    }
+  }, [tab]);
+
+  function select(srvUrl) {
+    setUrl(srvUrl);
+    fetch(`${srvUrl}/auth/server-fingerprint`)
+      .then((r) => (r.ok ? r.json() : Promise.reject()))
+      .then((d) => {
+        setFingerprint(d.fingerprint || '');
+        setServerId(d.id || d.serverId || '');
+      })
+      .catch(() => {
+        setFingerprint('');
+        setServerId('');
+      });
+  }
+
+  function handleManual() {
+    select(url);
+  }
+
+  function handleQR(e) {
+    try {
+      const data = JSON.parse(e.target.value);
+      setUrl(data.url || '');
+      setServerId(data.id || '');
+      setFingerprint(data.fingerprint || '');
+    } catch {
+      setUrl('');
+      setServerId('');
+      setFingerprint('');
+    }
+  }
+
+  function confirm() {
+    savePinnedServer({ id: serverId, url, fingerprint }).then(() =>
+      setSaved(true)
+    );
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-lg font-semibold">{t('connect.joinTitle')}</h2>
+      <div className="flex space-x-2">
+        <button
+          className={`px-2 py-1 border ${
+            tab === 'discover' ? 'bg-gray-200' : ''
+          }`}
+          onClick={() => setTab('discover')}
+        >
+          {t('connect.discover')}
+        </button>
+        <button
+          className={`px-2 py-1 border ${tab === 'manual' ? 'bg-gray-200' : ''}`}
+          onClick={() => setTab('manual')}
+        >
+          {t('connect.manual')}
+        </button>
+        <button
+          className={`px-2 py-1 border ${tab === 'scan' ? 'bg-gray-200' : ''}`}
+          onClick={() => setTab('scan')}
+        >
+          {t('connect.scan')}
+        </button>
+      </div>
+
+      {tab === 'discover' && (
+        <div className="space-y-2">
+          {servers.map((s) => (
+            <div key={s.id}>
+              <Button onClick={() => select(s.url)}>{s.url}</Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {tab === 'manual' && (
+        <div className="space-y-2">
+          <input
+            className="border p-1 w-full"
+            placeholder="https://example"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+          <Button onClick={handleManual}>{t('connect.manual')}</Button>
+        </div>
+      )}
+
+      {tab === 'scan' && (
+        <textarea
+          className="border p-1 w-full"
+          rows={3}
+          onChange={handleQR}
+          placeholder="{\"url\":\"https://...\",\"id\":\"...\",\"fingerprint\":\"...\"}"
+        />
+      )}
+
+      {fingerprint && (
+        <div className="space-y-2">
+          <div>
+            {t('connect.fingerprint')}: {fingerprint}
+          </div>
+          <Button onClick={confirm}>{t('connect.trust')}</Button>
+          {saved && <div>{t('connect.saved')}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/PromoteServer.tsx
+++ b/ui/src/pages/PromoteServer.tsx
@@ -1,0 +1,54 @@
+const { useState } = React;
+import Button from '../design/Button.tsx';
+const { useTranslation } = ReactI18next;
+
+export default function PromoteServer() {
+  const { t } = useTranslation();
+  const [info, setInfo] = useState(null);
+  const [invite, setInvite] = useState('');
+
+  function promote() {
+    fetch('/bootstrap/config', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mode: 'server', discovery: { announcer: true } }),
+    })
+      .then((res) => (res.ok ? fetch('/auth/server-fingerprint') : Promise.reject()))
+      .then((res) => res.json())
+      .then((data) => {
+        setInfo(data);
+        const payload = JSON.stringify({
+          url: window.location.origin,
+          id: data.id || data.serverId || '',
+          fingerprint: data.fingerprint,
+        });
+        setInvite(payload);
+      })
+      .catch(() => setInfo(null));
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <h2 className="text-lg font-semibold">{t('connect.promoteTitle')}</h2>
+      {!info && (
+        <Button onClick={promote}>{t('connect.promoteAction')}</Button>
+      )}
+      {info && (
+        <div className="space-y-2">
+          <div>
+            {t('connect.fingerprint')}: {info.fingerprint}
+          </div>
+          <div>
+            {t('connect.invite')}:
+            <div>
+              <img
+                alt="QR"
+                src={`https://api.qrserver.com/v1/create-qr-code/?data=${encodeURIComponent(invite)}`}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/SettingsAdmin.tsx
+++ b/ui/src/pages/SettingsAdmin.tsx
@@ -1,6 +1,21 @@
 import { useTranslation } from 'react-i18next';
+const { Link } = ReactRouterDOM;
 
 export default function SettingsAdmin() {
   const { t } = useTranslation();
-  return <div className="text-sm">{t('settings.admin')}</div>;
+  return (
+    <div className="space-y-2 text-sm">
+      <div>{t('settings.admin')}</div>
+      <div>
+        <Link className="text-blue-600" to="/settings/join">
+          {t('settings.join')}
+        </Link>
+      </div>
+      <div>
+        <Link className="text-blue-600" to="/settings/promote">
+          {t('settings.promote')}
+        </Link>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add UI pages to join a server and promote instance to server with fingerprint pinning
- store pinned server config via client-config endpoint and local tactix.config.json
- include EN/FR i18n strings and settings links

## Testing
- `pnpm --filter ui-web test`

------
https://chatgpt.com/codex/tasks/task_e_68a1e7d6b7f08323a378b50546e08fa5