### PR TITLE
feat(registry): add registry service and invite codes

### DIFF
--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,0 +1,14 @@
+# Registry Service
+
+The registry service allows TACTIX servers to publish a network address that remote clients can discover.
+
+## Endpoints
+
+- `POST /registry/register` – body: `{ serverId, url, fingerprint, signedRecord }`.
+- `GET /registry/lookup?serverId=...` – returns `{ url, fingerprint }` when a record exists.
+
+This reference implementation stores records in memory and exposes a simple health endpoint at `/health`.
+
+## Security
+
+The sample service performs no authentication and should only be used for experimentation.

--- a/packages/invite/package.json
+++ b/packages/invite/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tactix/invite",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "test": "pnpm build && node --test dist/test/**/*.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/packages/invite/src/index.ts
+++ b/packages/invite/src/index.ts
@@ -1,0 +1,33 @@
+import crypto from 'crypto';
+
+export interface InvitePayload {
+  serverId: string;
+  exp: number;
+  sig: string;
+}
+
+export function generateInvite(serverId: string, secret: string, expiresInSeconds = 300): string {
+  const exp = Math.floor(Date.now() / 1000) + expiresInSeconds;
+  const base = JSON.stringify({ serverId, exp });
+  const sig = crypto.createHmac('sha256', secret).update(base).digest('hex');
+  const full: InvitePayload = { serverId, exp, sig };
+  return Buffer.from(JSON.stringify(full)).toString('base64url');
+}
+
+export function decodeInvite(code: string): InvitePayload | null {
+  try {
+    return JSON.parse(Buffer.from(code, 'base64url').toString('utf8')) as InvitePayload;
+  } catch {
+    return null;
+  }
+}
+
+export function verifyInvite(code: string, secret: string): { serverId: string } | null {
+  const payload = decodeInvite(code);
+  if (!payload) return null;
+  if (payload.exp < Math.floor(Date.now() / 1000)) return null;
+  const base = JSON.stringify({ serverId: payload.serverId, exp: payload.exp });
+  const expected = crypto.createHmac('sha256', secret).update(base).digest('hex');
+  if (expected !== payload.sig) return null;
+  return { serverId: payload.serverId };
+}

--- a/packages/invite/test/invite.test.ts
+++ b/packages/invite/test/invite.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { generateInvite, verifyInvite, decodeInvite } from '../src/index.js';
+
+const secret = 's3cr3t';
+
+test('generate and verify invite', () => {
+  const code = generateInvite('srv1', secret, 60);
+  const valid = verifyInvite(code, secret);
+  assert.ok(valid && valid.serverId === 'srv1');
+});
+
+test('decode invite without secret', () => {
+  const code = generateInvite('srv2', secret, 60);
+  const decoded = decodeInvite(code);
+  assert.strictEqual(decoded?.serverId, 'srv2');
+});

--- a/packages/invite/tsconfig.json
+++ b/packages/invite/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/services/registry-svc/package.json
+++ b/services/registry-svc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "registry-svc",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "test": "pnpm build && node --test dist/test/**/*.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/services/registry-svc/src/index.ts
+++ b/services/registry-svc/src/index.ts
@@ -1,0 +1,31 @@
+import express from 'express';
+import { register, lookup } from './registry.js';
+
+const app = express();
+app.use(express.json());
+
+app.post('/registry/register', (req, res) => {
+  try {
+    register(req.body);
+    res.json({ ok: true });
+  } catch (err) {
+    res.status(400).json({ error: 'invalid' });
+  }
+});
+
+app.get('/registry/lookup', (req, res) => {
+  const serverId = req.query.serverId;
+  if (typeof serverId !== 'string') return res.status(400).json({ error: 'invalid' });
+  const entry = lookup(serverId);
+  if (!entry) return res.status(404).json({ error: 'not_found' });
+  res.json({ url: entry.url, fingerprint: entry.fingerprint });
+});
+
+app.get('/health', (_req, res) => res.json({ ok: true }));
+
+const port = process.env.PORT || 3000;
+if (import.meta.url === `file://${process.argv[1]}`) {
+  app.listen(port, () => console.log(`registry-svc listening on ${port}`));
+}
+
+export default app;

--- a/services/registry-svc/src/registry.ts
+++ b/services/registry-svc/src/registry.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const entrySchema = z.object({
+  serverId: z.string(),
+  url: z.string().url(),
+  fingerprint: z.string(),
+  signedRecord: z.string()
+});
+
+export type RegistryEntry = z.infer<typeof entrySchema>;
+
+const store = new Map<string, RegistryEntry>();
+
+export function register(entry: RegistryEntry) {
+  const data = entrySchema.parse(entry);
+  store.set(data.serverId, data);
+}
+
+export function lookup(serverId: string): RegistryEntry | undefined {
+  return store.get(serverId);
+}

--- a/services/registry-svc/test/registry.test.ts
+++ b/services/registry-svc/test/registry.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { register, lookup } from '../src/registry.js';
+
+test('register and lookup', () => {
+  register({ serverId: 'abc', url: 'https://example.com', fingerprint: 'fp', signedRecord: 'sig' });
+  const found = lookup('abc');
+  assert.ok(found && found.url === 'https://example.com');
+});

--- a/services/registry-svc/tsconfig.json
+++ b/services/registry-svc/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/ui/app.tsx
+++ b/ui/app.tsx
@@ -11,6 +11,7 @@ import EngRooms from './src/pages/EngRooms.tsx';
 import EngRoom from './src/pages/EngRoom.tsx';
 import SettingsProfile from './src/pages/SettingsProfile.tsx';
 import SettingsAdmin from './src/pages/SettingsAdmin.tsx';
+import InvitePage from './src/pages/InvitePage.tsx';
 import NotFound from './src/pages/NotFound.tsx';
 import ErrorPage from './src/pages/ErrorPage.tsx';
 import { notifyStore } from './src/lib/notify.ts';
@@ -126,6 +127,7 @@ function App() {
                 <Route path="eng/rooms/:roomId" element={<EngRoom />} />
               </>
             )}
+            <Route path="invite" element={<InvitePage />} />
             <Route path="settings/profile" element={<SettingsProfile />} />
             <Route path="settings/admin" element={<SettingsAdmin />} />
             <Route path="error" element={<ErrorPage />} />

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,8 @@
     "react-dom": "^18.2.0",
     "i18next": "^23.7.6",
     "react-i18next": "^13.0.0",
-    "react-router-dom": "^6.23.0"
+    "react-router-dom": "^6.23.0",
+    "@tactix/invite": "workspace:*",
+    "qrcode.react": "^3.1.0"
   }
 }

--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -20,7 +20,9 @@
     "logout": "Logout"
   },
   "header": {
-    "search": { "placeholder": "Search" },
+    "search": {
+      "placeholder": "Search"
+    },
     "notifications": "Notifications",
     "language": "Language",
     "logout": "Logout"
@@ -48,7 +50,9 @@
     "title": "Playbooks"
   },
   "orders": {
-    "list": { "title": "Orders" }
+    "list": {
+      "title": "Orders"
+    }
   },
   "settings": {
     "profile": "Profile",
@@ -135,5 +139,15 @@
       "done": "Done",
       "cancelled": "Cancelled"
     }
+  },
+  "invite": {
+    "generate": "Generate Invite Code",
+    "serverId": "Server ID",
+    "secret": "Secret",
+    "code": "Invite Code",
+    "join": "Join by Invite Code",
+    "paste": "Invite Code",
+    "submit": "Join",
+    "invalid": "Invalid or expired code"
   }
 }

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -20,7 +20,9 @@
     "logout": "Déconnexion"
   },
   "header": {
-    "search": { "placeholder": "Recherche" },
+    "search": {
+      "placeholder": "Recherche"
+    },
     "notifications": "Notifications",
     "language": "Langue",
     "logout": "Déconnexion"
@@ -48,7 +50,9 @@
     "title": "Playbooks"
   },
   "orders": {
-    "list": { "title": "Ordres" }
+    "list": {
+      "title": "Ordres"
+    }
   },
   "settings": {
     "profile": "Profil",
@@ -135,5 +139,15 @@
       "done": "Terminée",
       "cancelled": "Annulée"
     }
+  },
+  "invite": {
+    "generate": "Générer un code d'invitation",
+    "serverId": "ID du serveur",
+    "secret": "Secret",
+    "code": "Code d'invitation",
+    "join": "Rejoindre par code d'invitation",
+    "paste": "Code d'invitation",
+    "submit": "Rejoindre",
+    "invalid": "Code invalide ou expiré"
   }
 }

--- a/ui/src/pages/InvitePage.tsx
+++ b/ui/src/pages/InvitePage.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { generateInvite, decodeInvite } from '@tactix/invite';
+import { QRCodeCanvas } from 'qrcode.react';
+
+export default function InvitePage() {
+  const { t } = useTranslation();
+  const [serverId, setServerId] = useState('');
+  const [secret, setSecret] = useState('');
+  const [code, setCode] = useState('');
+  const [joinCode, setJoinCode] = useState('');
+  const [joinResult, setJoinResult] = useState('');
+
+  function gen() {
+    try {
+      setCode(generateInvite(serverId, secret));
+    } catch {
+      setCode('');
+    }
+  }
+
+  async function join() {
+    const payload = decodeInvite(joinCode);
+    if (!payload) {
+      setJoinResult(t('invite.invalid'));
+      return;
+    }
+    const res = await fetch(`/registry/lookup?serverId=${encodeURIComponent(payload.serverId)}`);
+    if (res.ok) {
+      const data = await res.json();
+      setJoinResult(JSON.stringify(data));
+    } else {
+      setJoinResult(t('invite.invalid'));
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">{t('invite.generate')}</h2>
+        <input className="border p-1" placeholder={t('invite.serverId')} value={serverId} onChange={e=>setServerId(e.target.value)} />
+        <input className="border p-1" placeholder={t('invite.secret')} value={secret} onChange={e=>setSecret(e.target.value)} />
+        <button className="border px-2" onClick={gen}>{t('invite.generate')}</button>
+        {code && (
+          <div className="space-y-2">
+            <textarea className="border w-full" value={code} readOnly />
+            <QRCodeCanvas value={code} />
+          </div>
+        )}
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">{t('invite.join')}</h2>
+        <input className="border p-1" placeholder={t('invite.paste')} value={joinCode} onChange={e=>setJoinCode(e.target.value)} />
+        <button className="border px-2" onClick={join}>{t('invite.submit')}</button>
+        {joinResult && <div className="text-sm break-all">{joinResult}</div>}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add in-memory registry service with register and lookup endpoints
- introduce invite code package for generating/validating codes
- add UI page to create and join via invite codes with QR rendering
- document registry service usage

## Affected Services
- registry-svc (new)
- ui

## Testing
- `pnpm --filter @tactix/invite install` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm --filter @tactix/invite test` *(fails: Cannot find module 'crypto' types)*
- `pnpm --filter registry-svc install` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm --filter registry-svc test` *(fails: Cannot find module 'express' types)*
- `pnpm --filter ui-web install` *(fails: ERR_PNPM_FETCH_403 Forbidden)*
- `pnpm --filter ui-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e7febed483239c82e3f3cbc41155