### PR TITLE
chore: add zero trust audit tool

### DIFF
--- a/.github/workflows/zt-audit.yml
+++ b/.github/workflows/zt-audit.yml
@@ -1,0 +1,20 @@
+name: zt-audit
+
+on:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: corepack enable
+      - run: pnpm -r install
+      - run: pnpm zt:audit:ci

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 npm-debug.log
 dist
 !services/incident-svc/dist/
+
+zt-audit.json

--- a/docs/zt-audit.md
+++ b/docs/zt-audit.md
@@ -1,0 +1,24 @@
+# Zero Trust Audit Tool
+
+The `zt-audit` script scans the repository for common security gaps:
+
+- Comment markers such as `TODO` or `FIXME`
+- Route handlers missing `requireAuth`
+- WebSocket connections without token checks
+- Services missing `/health` or `/openapi.json`
+- Unused variables in `.env.example`
+- Services that may not log a startup summary
+
+Run locally:
+
+```bash
+pnpm zt:audit
+```
+
+CI uses:
+
+```bash
+pnpm zt:audit:ci
+```
+
+The audit generates `zt-audit.json` with details and exits non-zero in CI mode when high severity issues are found.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "dev": "pnpm -r dev",
     "test": "pnpm -r test",
     "test:ci": "pnpm -r test",
-    "migrate": "pnpm -r migrate"
+    "migrate": "pnpm -r migrate",
+    "zt:audit": "node tools/zt-audit.mjs",
+    "zt:audit:ci": "node tools/zt-audit.mjs --ci"
   }
 }

--- a/tools/zt-audit.mjs
+++ b/tools/zt-audit.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const ci = process.argv.includes('--ci');
+const issues = [];
+
+function addIssue(issue) {
+  issues.push(issue);
+}
+
+const markerRe = /(TODO|FIXME|HACK|XXX|STUB|TBD|PENDING)/;
+const routeRe = /router\.(get|post|patch|delete)\(([^)]*)\)/g;
+const wsConnRe = /\.on\(['"]connection['"]/;
+
+const gitFiles = execSync('git ls-files', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean);
+
+const textExtensions = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.json',
+  '.md',
+  '.env',
+  '.sh',
+  '.yml',
+  '.yaml',
+]);
+
+const fileContents = new Map();
+
+for (const file of gitFiles) {
+  const ext = path.extname(file);
+  if (!textExtensions.has(ext)) continue;
+  const content = await readFile(file, 'utf8');
+  fileContents.set(file, content);
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, idx) => {
+    if (markerRe.test(line)) {
+      addIssue({
+        severity: 'high',
+        kind: 'marker',
+        file,
+        line: idx + 1,
+        message: line.trim(),
+      });
+    }
+  });
+
+  let match;
+  while ((match = routeRe.exec(content))) {
+    const routeDef = match[0];
+    if (!/requireAuth/.test(routeDef)) {
+      const line = content.slice(0, match.index).split(/\r?\n/).length;
+      addIssue({
+        severity: 'high',
+        kind: 'route-auth',
+        file,
+        line,
+        message: `Route missing requireAuth: ${routeDef.trim()}`,
+      });
+    }
+  }
+
+  if (wsConnRe.test(content)) {
+    if (!/token|Sec-WebSocket-Protocol/.test(content)) {
+      const line = lines.findIndex((l) => wsConnRe.test(l)) + 1;
+      addIssue({
+        severity: 'high',
+        kind: 'ws-auth',
+        file,
+        line,
+        message: 'WebSocket connection handler lacks token verification',
+      });
+    }
+  }
+}
+
+// Service checks
+const serviceDirs = gitFiles
+  .filter((f) => f.startsWith('services/'))
+  .map((f) => f.split('/')[1])
+  .filter((v, i, arr) => arr.indexOf(v) === i);
+
+for (const svc of serviceDirs) {
+  const svcFiles = gitFiles.filter((f) => f.startsWith(`services/${svc}/`));
+  const svcContent = svcFiles
+    .map((f) => fileContents.get(f) || '')
+    .join('\n');
+
+  if (!/\/health/.test(svcContent)) {
+    addIssue({
+      severity: 'high',
+      kind: 'health',
+      file: `services/${svc}`,
+      message: 'Missing /health endpoint',
+    });
+  }
+
+  if (!/openapi\.json/.test(svcContent)) {
+    addIssue({
+      severity: 'high',
+      kind: 'openapi',
+      file: `services/${svc}`,
+      message: 'Missing /openapi.json exporter',
+    });
+  }
+
+  if (!/port/i.test(svcContent) || !/mode/i.test(svcContent)) {
+    addIssue({
+      severity: 'info',
+      kind: 'startup-log',
+      file: `services/${svc}`,
+      message: 'Service may not log startup summary (port/mode)',
+    });
+  }
+}
+
+// .env.example variables
+const envFiles = gitFiles.filter((f) => f.endsWith('.env.example'));
+const allText = Array.from(fileContents.values()).join('\n');
+for (const envFile of envFiles) {
+  const content = fileContents.get(envFile) || '';
+  const vars = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#') && l.includes('='))
+    .map((l) => l.split('=')[0]);
+  for (const v of vars) {
+    const re = new RegExp(`\b${v}\b`);
+    if (!re.test(allText)) {
+      addIssue({
+        severity: 'info',
+        kind: 'env-unused',
+        file: envFile,
+        message: `Variable not referenced: ${v}`,
+      });
+    }
+  }
+}
+
+const summary = {
+  high: issues.filter((i) => i.severity === 'high').length,
+  info: issues.filter((i) => i.severity === 'info').length,
+};
+
+await writeFile('zt-audit.json', JSON.stringify({ issues, summary }, null, 2));
+
+if (issues.length) {
+  console.log('ZT Audit Report');
+  console.table(
+    issues.map((i) => ({
+      severity: i.severity,
+      kind: i.kind,
+      location: i.line ? `${i.file}:${i.line}` : i.file,
+      message: i.message,
+    }))
+  );
+} else {
+  console.log('ZT Audit: no issues found');
+}
+
+if (ci && summary.high > 0) {
+  process.exitCode = 1;
+}

--- a/tools/zt-audit.ts
+++ b/tools/zt-audit.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+
+import { execSync } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+interface Issue {
+  severity: 'high' | 'info';
+  kind: string;
+  file: string;
+  line?: number;
+  message: string;
+}
+
+const ci = process.argv.includes('--ci');
+const issues: Issue[] = [];
+
+function addIssue(issue: Issue) {
+  issues.push(issue);
+}
+
+const markerRe = /(TODO|FIXME|HACK|XXX|STUB|TBD|PENDING)/;
+const routeRe = /router\.(get|post|patch|delete)\(([^)]*)\)/g;
+const wsConnRe = /\.on\(['"]connection['"]/;
+
+const gitFiles = execSync('git ls-files', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean);
+
+const textExtensions = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.json',
+  '.md',
+  '.env',
+  '.sh',
+  '.yml',
+  '.yaml',
+]);
+
+const fileContents = new Map<string, string>();
+
+for (const file of gitFiles) {
+  const ext = path.extname(file);
+  if (!textExtensions.has(ext)) continue;
+  const content = await readFile(file, 'utf8');
+  fileContents.set(file, content);
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, idx) => {
+    if (markerRe.test(line)) {
+      addIssue({
+        severity: 'high',
+        kind: 'marker',
+        file,
+        line: idx + 1,
+        message: line.trim(),
+      });
+    }
+  });
+
+  let match: RegExpExecArray | null;
+  while ((match = routeRe.exec(content))) {
+    const routeDef = match[0];
+    if (!/requireAuth/.test(routeDef)) {
+      const line = content.slice(0, match.index).split(/\r?\n/).length;
+      addIssue({
+        severity: 'high',
+        kind: 'route-auth',
+        file,
+        line,
+        message: `Route missing requireAuth: ${routeDef.trim()}`,
+      });
+    }
+  }
+
+  if (wsConnRe.test(content)) {
+    if (!/token|Sec-WebSocket-Protocol/.test(content)) {
+      const line = lines.findIndex((l) => wsConnRe.test(l)) + 1;
+      addIssue({
+        severity: 'high',
+        kind: 'ws-auth',
+        file,
+        line,
+        message: 'WebSocket connection handler lacks token verification',
+      });
+    }
+  }
+}
+
+// Service checks
+const serviceDirs = gitFiles
+  .filter((f) => f.startsWith('services/'))
+  .map((f) => f.split('/')[1])
+  .filter((v, i, arr) => arr.indexOf(v) === i);
+
+for (const svc of serviceDirs) {
+  const svcFiles = gitFiles.filter((f) => f.startsWith(`services/${svc}/`));
+  const svcContent = svcFiles
+    .map((f) => fileContents.get(f) || '')
+    .join('\n');
+
+  if (!/\/health/.test(svcContent)) {
+    addIssue({
+      severity: 'high',
+      kind: 'health',
+      file: `services/${svc}`,
+      message: 'Missing /health endpoint',
+    });
+  }
+
+  if (!/openapi\.json/.test(svcContent)) {
+    addIssue({
+      severity: 'high',
+      kind: 'openapi',
+      file: `services/${svc}`,
+      message: 'Missing /openapi.json exporter',
+    });
+  }
+
+  if (!/port/i.test(svcContent) || !/mode/i.test(svcContent)) {
+    addIssue({
+      severity: 'info',
+      kind: 'startup-log',
+      file: `services/${svc}`,
+      message: 'Service may not log startup summary (port/mode)',
+    });
+  }
+}
+
+// .env.example variables
+const envFiles = gitFiles.filter((f) => f.endsWith('.env.example'));
+const allText = Array.from(fileContents.values()).join('\n');
+for (const envFile of envFiles) {
+  const content = fileContents.get(envFile) || '';
+  const vars = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('#') && l.includes('='))
+    .map((l) => l.split('=')[0]);
+  for (const v of vars) {
+    const re = new RegExp(`\b${v}\b`);
+    if (!re.test(allText)) {
+      addIssue({
+        severity: 'info',
+        kind: 'env-unused',
+        file: envFile,
+        message: `Variable not referenced: ${v}`,
+      });
+    }
+  }
+}
+
+const summary = {
+  high: issues.filter((i) => i.severity === 'high').length,
+  info: issues.filter((i) => i.severity === 'info').length,
+};
+
+await writeFile('zt-audit.json', JSON.stringify({ issues, summary }, null, 2));
+
+if (issues.length) {
+  console.log('ZT Audit Report');
+  console.table(
+    issues.map((i) => ({
+      severity: i.severity,
+      kind: i.kind,
+      location: i.line ? `${i.file}:${i.line}` : i.file,
+      message: i.message,
+    }))
+  );
+} else {
+  console.log('ZT Audit: no issues found');
+}
+
+if (ci && summary.high > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add repository scanner for TODOs, missing auth guards, ws auth, health and openapi checks
- add CI workflow and pnpm scripts to run zt audit
- document `pnpm zt:audit`

## Testing
- `pnpm zt:audit`
- `pnpm test` *(fails: ReferenceError: test is not defined in services/rbac)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f953ee1483238404e1283f06dc31