### PR TITLE
feat(rbac): implement in-memory role assignments

### DIFF
--- a/services/rbac/src/index.test.ts
+++ b/services/rbac/src/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import { computeEffective, can } from './index';
+import { computeEffective, can, assignRole, getAssignedRole, clearAssignments } from './index';
 
 test('AD-derived VIEWER via suffix match', () => {
   const eff = computeEffective({
@@ -21,4 +21,11 @@ test('DB grant overrides to EDITOR', () => {
   expect(eff.roles.includes('EDITOR')).toBe(true);
   expect(can(eff.roles, 'WRITE')).toBe(true);
   expect(can(eff.roles, 'ASSIGN')).toBe(false);
+});
+
+test('assignRole stores role for user and operation', async () => {
+  clearAssignments();
+  await assignRole('user@example.com', 'EDITOR', 'OPX123', 'admin@example.com');
+  const role = await getAssignedRole('user@example.com', 'OPX123');
+  expect(role).toBe('EDITOR');
 });

--- a/services/rbac/src/index.ts
+++ b/services/rbac/src/index.ts
@@ -59,9 +59,26 @@ export function can(roles: Role[] | Set<Role>, action: Action): boolean {
   return ACTION_MAP[action].some(r => have.has(r));
 }
 
-// Placeholder assign & check — to be replaced with real DB-backed logic.
-export async function assignRole(_userUpn: string, _role: Role, _operationId: string, _byUpn: string): Promise<void> {
-  console.log('[RBAC] TODO assignRole', { _userUpn, _role, _operationId, _byUpn });
+// In-memory assignment store; replace with persistent DB logic in services.
+const assignments = new Map<string, Role>();
+
+export async function assignRole(
+  userUpn: string,
+  role: Role,
+  operationId: string,
+  _byUpn: string,
+): Promise<void> {
+  const key = `${userUpn.toLowerCase()}::${operationId}`;
+  assignments.set(key, role);
+}
+
+export async function getAssignedRole(userUpn: string, operationId: string): Promise<Role | null> {
+  const key = `${userUpn.toLowerCase()}::${operationId}`;
+  return assignments.get(key) ?? null;
+}
+
+export function clearAssignments(): void {
+  assignments.clear();
 }
 
 export async function checkPermission(eff: EffectiveResult, action: Action): Promise<boolean> {


### PR DESCRIPTION
## Summary
- implement in-memory role assignment store
- add tests covering assignRole and retrieval

## Testing
- `pnpm --filter @tactix/rbac test`

------
https://chatgpt.com/codex/tasks/task_e_68a2129827988323b61decc8032c1faa