### PR TITLE
ci: install pnpm before node setup

### DIFF
--- a/.github/workflows/zt-audit.yml
+++ b/.github/workflows/zt-audit.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
       - run: corepack enable
       - run: pnpm -r install
       - run: pnpm zt:audit:ci


### PR DESCRIPTION
## Summary
- fix audit workflow so pnpm is available during Node setup cache step

## Testing
- `pnpm -r install`
- `pnpm zt:audit:ci` *(fails: high severity findings)*

------
https://chatgpt.com/codex/tasks/task_e_68a247e22bf08323bde6c70f2321be45