### PR TITLE
feat(ui): add home page welcome message

### DIFF
--- a/ui/src/i18n/locales/en/common.json
+++ b/ui/src/i18n/locales/en/common.json
@@ -28,6 +28,9 @@
   "footer": {
     "build": "Build"
   },
+  "home": {
+    "welcome": "Welcome to TACTIX"
+  },
   "auth": {
     "login": {
       "title": "Sign in",

--- a/ui/src/i18n/locales/fr/common.json
+++ b/ui/src/i18n/locales/fr/common.json
@@ -28,6 +28,9 @@
   "footer": {
     "build": "Version"
   },
+  "home": {
+    "welcome": "Bienvenue dans TACTIX"
+  },
   "auth": {
     "login": {
       "title": "Connexion",

--- a/ui/src/pages/OperationsList.tsx
+++ b/ui/src/pages/OperationsList.tsx
@@ -2,5 +2,10 @@ import { useTranslation } from 'react-i18next';
 
 export default function OperationsList() {
   const { t } = useTranslation();
-  return <div className="text-sm">{t('nav.operations')}</div>;
+  return (
+    <div className="space-y-2 text-sm">
+      <h1 className="text-xl font-semibold">{t('home.welcome')}</h1>
+      <div>{t('nav.operations')}</div>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- display localized welcome heading on operations home page

## Testing
- `pnpm --filter ui-web test`


------
https://chatgpt.com/codex/tasks/task_e_68a52d9a138083239daa06ab9e97e133