### PR TITLE
feat: add sitrep generator agent

### DIFF
--- a/data/incident/incident1.json
+++ b/data/incident/incident1.json
@@ -1,0 +1,1 @@
+{"id":1,"title":"Power outage","description":"Brief outage in sector 7","severity":"minor"}

--- a/data/incident/incident2.json
+++ b/data/incident/incident2.json
@@ -1,0 +1,1 @@
+{"id":2,"title":"Fuel leak","description":"Leak detected near depot","severity":"major"}

--- a/data/incident/incident3.json
+++ b/data/incident/incident3.json
@@ -1,0 +1,1 @@
+{"id":3,"title":"Unauthorized entry","description":"Intruder at gate","severity":"critical"}

--- a/data/incident/incident4.json
+++ b/data/incident/incident4.json
@@ -1,0 +1,1 @@
+{"id":4,"title":"Network glitch","description":"Packet loss observed","severity":"info"}

--- a/data/incident/incident5.json
+++ b/data/incident/incident5.json
@@ -1,0 +1,1 @@
+{"id":5,"title":"Weather alert","description":"Storm approaching","severity":"minor"}

--- a/data/reports/sitreps/SITREP_20250820-0238.md
+++ b/data/reports/sitreps/SITREP_20250820-0238.md
@@ -1,0 +1,8 @@
+# SITREP
+
+Loaded 5 incidents.
+
+SOP:
+# Current Ops SOP
+Ensure perimeter is secured. Report all CCIR breaches immediately.
+

--- a/data/sop/refs/current_ops.md
+++ b/data/sop/refs/current_ops.md
@@ -1,0 +1,2 @@
+# Current Ops SOP
+Ensure perimeter is secured. Report all CCIR breaches immediately.

--- a/prompts/sitrep_prompt.md
+++ b/prompts/sitrep_prompt.md
@@ -1,0 +1,26 @@
+# Claude Prompt Template
+
+You are a Duty Officer AI assistant. Based on the following incident logs and SOP guidance, generate a SITREP in markdown format. Include a Summary, Key Events, CCIRs, and Recommendations if possible.
+
+## Context
+- **INCIDENTS**: {{incident_json_summary}}
+- **SOP**: {{sop_guidance}}
+
+## Output Format
+```
+# SITREP – {{datetime}}
+
+## Summary
+...
+
+## Key Events
+- Event 1
+- Event 2
+
+## CCIRs Triggered
+- CCIR #3: Unit X breached sector boundary
+
+## Recommendations
+- Notify G3
+- Prepare Quick Reaction Force
+```

--- a/public/mock/agent_tasks.json
+++ b/public/mock/agent_tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "agent": "sitrep_agent",
+    "task": "Generated SITREP from 5 incident logs",
+    "timestamp": "2025-08-20T02:38:59.121Z",
+    "output_file": "reports/sitreps/SITREP_20250820-0238.md"
+  }
+]

--- a/src/agents/sitrep_agent.ts
+++ b/src/agents/sitrep_agent.ts
@@ -1,0 +1,140 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const INCIDENT_DIR = path.resolve('data/incident');
+const SOP_PATH = path.resolve('data/sop/refs/current_ops.md');
+const PROMPT_PATH = path.resolve('prompts/sitrep_prompt.md');
+const REPORT_DIR = path.resolve('data/reports/sitreps');
+const TASK_LOG = path.resolve('public/mock/agent_tasks.json');
+
+interface ContextBundle {
+  incidents: any[];
+  summary: string;
+  sopText: string;
+}
+
+async function loadIncidents(): Promise<any[]> {
+  const files = await fs.readdir(INCIDENT_DIR);
+  const stats = await Promise.all(
+    files.map(async (f) => {
+      const full = path.join(INCIDENT_DIR, f);
+      const stat = await fs.stat(full);
+      return { file: f, mtime: stat.mtimeMs };
+    })
+  );
+  stats.sort((a, b) => b.mtime - a.mtime);
+  const selected = stats.slice(0, 5);
+  const incidents = await Promise.all(
+    selected.map(async ({ file }) => {
+      const content = await fs.readFile(path.join(INCIDENT_DIR, file), 'utf8');
+      return JSON.parse(content);
+    })
+  );
+  return incidents;
+}
+
+async function loadSop(): Promise<string> {
+  try {
+    return await fs.readFile(SOP_PATH, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function buildContext(incidents: any[], sopText: string): ContextBundle {
+  return {
+    incidents,
+    summary: `Loaded ${incidents.length} incidents`,
+    sopText,
+  };
+}
+
+async function buildPrompt(ctx: ContextBundle): Promise<string> {
+  const template = await fs.readFile(PROMPT_PATH, 'utf8');
+  return template
+    .replace('{{incident_json_summary}}', JSON.stringify(ctx.incidents, null, 2))
+    .replace('{{sop_guidance}}', ctx.sopText)
+    .replace('{{datetime}}', new Date().toISOString());
+}
+
+async function callClaude(prompt: string): Promise<string> {
+  const apiKey = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+  if (!apiKey) {
+    console.warn('Claude API key not set. Returning placeholder text.');
+    return '# SITREP\n\nNo API key provided.';
+  }
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-3-opus-20240229',
+      max_tokens: 500,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Claude API error: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  const content = Array.isArray(data.content)
+    ? data.content.map((c: any) => c.text || '').join('\n')
+    : data.completion || '';
+  return content;
+}
+
+function formatTimestamp(d: Date): string {
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-${pad(d.getHours())}${pad(d.getMinutes())}`;
+}
+
+async function saveReport(markdown: string): Promise<string> {
+  await fs.mkdir(REPORT_DIR, { recursive: true });
+  const name = `SITREP_${formatTimestamp(new Date())}.md`;
+  const full = path.join(REPORT_DIR, name);
+  await fs.writeFile(full, markdown, 'utf8');
+  return full;
+}
+
+async function logTask(outputFile: string): Promise<void> {
+  await fs.mkdir(path.dirname(TASK_LOG), { recursive: true });
+  let log: any[] = [];
+  try {
+    log = JSON.parse(await fs.readFile(TASK_LOG, 'utf8'));
+  } catch {
+    log = [];
+  }
+  log.push({
+    agent: 'sitrep_agent',
+    task: 'Generated SITREP from 5 incident logs',
+    timestamp: new Date().toISOString(),
+    output_file: outputFile.replace(/^.*data\//, ''),
+  });
+  await fs.writeFile(TASK_LOG, JSON.stringify(log, null, 2));
+}
+
+export async function main(): Promise<void> {
+  try {
+    const incidents = await loadIncidents();
+    const sop = await loadSop();
+    const ctx = buildContext(incidents, sop);
+    const prompt = await buildPrompt(ctx);
+    const report = await callClaude(prompt);
+    const file = await saveReport(report);
+    await logTask(file);
+    console.log(`SITREP saved to ${file}`);
+  } catch (err) {
+    console.error('Failed to generate SITREP', err);
+    await logTask('ERROR');
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add SITREP generator agent that bundles recent incidents and SOP text then sends to Claude
- provide SITREP prompt template and sample data
- log generated reports and store output markdown under reports/sitreps

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a53463435883238af9ce9fe039c0cd